### PR TITLE
27 cli   update default ollama model from llama2 to llama3

### DIFF
--- a/src/commands/general/init.ts
+++ b/src/commands/general/init.ts
@@ -162,7 +162,7 @@ export async function initAction(options: InitActionOptions) {
 
   // Ollama doesn't need changes in configuration, we just run it
   if (selectedLlmProviders.includes("ollama")) {
-    console.log("Pulling llama2 from Ollama...");
+    console.log("Pulling llama3 from Ollama...");
     await pullOllamaModel();
   }
 
@@ -188,7 +188,7 @@ export async function initAction(options: InitActionOptions) {
     //remove all validators
     await deleteAllValidators();
     // create random validators
-    await createRandomValidators();
+    await createRandomValidators(Number(options.numValidators));
   } catch (error) {
     console.error("Unable to initialize the validators.");
     console.error(error);

--- a/src/lib/clients/system.ts
+++ b/src/lib/clients/system.ts
@@ -13,7 +13,6 @@ export async function checkCommand(command: string, toolName: string): Promise<v
   if (stderr) {
     throw new MissingRequirementError(toolName);
   }
-  console.log(`${toolName} is installed.`);
 }
 
 type ExecuteCommandResult = {

--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -6,9 +6,9 @@ export const DEFAULT_RUN_SIMULATOR_COMMAND = (simulatorLocation: string) => ({
   linux: `x-terminal-emulator -e bash -c 'cd ${simulatorLocation} && docker compose build && docker compose up; echo "Press enter to exit"; read'`,
 });
 export const DEFAULT_PULL_OLLAMA_COMMAND = (simulatorLocation: string) => ({
-  darwin: `osascript -e 'tell application "Terminal" to do script "cd ${simulatorLocation} && docker exec ollama ollama pull llama2"'`,
-  win32: `start cmd.exe /c "cd /d ${simulatorLocation} && docker exec ollama ollama pull llama2"`,
-  linux: `x-terminal-emulator -e bash -c 'cd ${simulatorLocation} && docker exec ollama ollama pull llama2'`,
+  darwin: `cd ${simulatorLocation} && docker exec ollama ollama pull llama3`,
+  win32: `cd /d ${simulatorLocation} && docker exec ollama ollama pull llama3`,
+  linux: `cd ${simulatorLocation} && docker exec ollama ollama pull llama3`,
 });
 export const AVAILABLE_PLATFORMS = ["darwin", "win32", "linux"] as const;
 export type RunningPlatform = (typeof AVAILABLE_PLATFORMS)[number];
@@ -23,7 +23,7 @@ export type AiProvidersConfigType = {
 
 export const AI_PROVIDERS_CONFIG: AiProvidersConfigType = {
   ollama: {
-    name: "Ollama (This will download and run a local instance of Llama 2)",
+    name: "Ollama (This will download and run a local instance of Llama 3)",
     cliOptionValue: "ollama",
   },
   openai: {

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -159,7 +159,12 @@ export async function waitForSimulatorToBeReady(
       return waitForSimulatorToBeReady(retries - 1);
     }
   } catch (error: any) {
-    if ((error.message.includes("ECONNREFUSED") || error.message.includes("socket hang up")) && retries > 0) {
+    if (
+      (error.message.includes("ECONNRESET") ||
+        error.message.includes("ECONNREFUSED") ||
+        error.message.includes("socket hang up")) &&
+      retries > 0
+    ) {
       await sleep(STARTING_TIMEOUT_WAIT_CYLCE * 2);
       return waitForSimulatorToBeReady(retries - 1);
     }
@@ -184,8 +189,8 @@ export async function initializeDatabase(): Promise<InitializeDatabaseResultType
   return {createResponse, tablesResponse};
 }
 
-export function createRandomValidators(): Promise<any> {
-  return rpcClient.request({method: "create_random_validators", params: [10, 1, 10]});
+export function createRandomValidators(numValidators: number): Promise<any> {
+  return rpcClient.request({method: "create_random_validators", params: [numValidators, 1, 10]});
 }
 
 export function deleteAllValidators(): Promise<any> {


### PR DESCRIPTION
- Upgraded from llama2 to llama3
- Pulling the ollama model now blocks the process instead of opening a new terminal
- Minor fixes and improvements

To remove the current llama2 model that you might have, please execute first:
`docker exec ollama ollama rm llama2` <--- This will be added soon to the CLI

@MuncleUscles could you please give it a try on Windows?