### PR TITLE
29 cli: add default number of validators to start command

### DIFF
--- a/src/commands/general/index.ts
+++ b/src/commands/general/index.ts
@@ -15,6 +15,7 @@ export function initializeGeneralCommands(program: Command) {
     .description("Starts GenLayer's simulator")
     .option("--no-reset-accounts", "Don't restart the database for accouts and transactions", true)
     .option("--reset-validators", "Remove all current validators and create new random ones", false)
+    .option("--numValidators <numValidators>", "Number of validators", "5")
     .action(startAction);
 
   return program;

--- a/src/commands/general/init.ts
+++ b/src/commands/general/init.ts
@@ -84,7 +84,7 @@ export async function initAction(options: InitActionOptions) {
       type: "checkbox",
       name: "selectedLlmProviders",
       message: "Select which LLM providers do you want to use:",
-      choices: getAiProvidersOptions(),
+      choices: getAiProvidersOptions(true),
       validate: function (answer: string[]) {
         if (answer.length < 1) {
           return "You must choose at least one option.";
@@ -188,7 +188,7 @@ export async function initAction(options: InitActionOptions) {
     //remove all validators
     await deleteAllValidators();
     // create random validators
-    await createRandomValidators(Number(options.numValidators));
+    await createRandomValidators(Number(options.numValidators), selectedLlmProviders);
   } catch (error) {
     console.error("Unable to initialize the validators.");
     console.error(error);

--- a/src/commands/general/start.ts
+++ b/src/commands/general/start.ts
@@ -99,7 +99,7 @@ export async function startAction(options: StartActionOptions) {
           type: "checkbox",
           name: "selectedLlmProviders",
           message: "Select which LLM providers do you want to use:",
-          choices: getAiProvidersOptions(true),
+          choices: getAiProvidersOptions(false),
           validate: function (answer: string[]) {
             if (answer.length < 1) {
               return "You must choose at least one option.";

--- a/src/commands/general/start.ts
+++ b/src/commands/general/start.ts
@@ -13,17 +13,18 @@ import {
 export interface StartActionOptions {
   resetAccounts: string;
   resetValidators: string;
+  numValidators: number;
 }
 
 export async function startAction(options: StartActionOptions) {
-  const {resetAccounts, resetValidators} = options;
+  const {resetAccounts, resetValidators, numValidators} = options;
 
   const restartAccountsHintText = resetAccounts
     ? "restarting the accounts and transactions database"
     : "keeping the accounts and transactions records";
 
   const restartValidatorsHintText = resetValidators
-    ? "and creating new random validators"
+    ? `and creating new ${numValidators} random validators`
     : "and keeping the existing validators";
 
   console.log(`Starting GenLayer simulator ${restartAccountsHintText} ${restartValidatorsHintText}`);
@@ -91,7 +92,7 @@ export async function startAction(options: StartActionOptions) {
       //remove all validators
       await deleteAllValidators();
       // create random validators
-      await createRandomValidators();
+      await createRandomValidators(Number(options.numValidators));
     } catch (error) {
       console.error("Unable to initialize the validators.");
       console.error(error);

--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -15,25 +15,28 @@ export type RunningPlatform = (typeof AVAILABLE_PLATFORMS)[number];
 export const STARTING_TIMEOUT_WAIT_CYLCE = 2000;
 export const STARTING_TIMEOUT_ATTEMPTS = 120;
 
-export type AiProviders = "ollama" | "openai" | "heurist";
+export type AiProviders = "ollama" | "openai" | "heuristai";
 export type AiProvidersEnvVars = "ollama" | "OPENAIKEY" | "HEURISTAIAPIKEY";
 export type AiProvidersConfigType = {
-  [key in AiProviders]: {name: string; envVar?: AiProvidersEnvVars; cliOptionValue: string};
+  [key in AiProviders]: {name: string; hint: string; envVar?: AiProvidersEnvVars; cliOptionValue: string};
 };
 
 export const AI_PROVIDERS_CONFIG: AiProvidersConfigType = {
   ollama: {
-    name: "Ollama (This will download and run a local instance of Llama 3)",
+    name: "Ollama",
+    hint: "(This will download and run a local instance of Llama 3)",
     cliOptionValue: "ollama",
   },
   openai: {
-    name: "OpenAI (You will need to provide an OpenAI API key)",
+    name: "OpenAI",
+    hint: "(You will need to provide an OpenAI API key)",
     envVar: "OPENAIKEY",
     cliOptionValue: "openai",
   },
-  heurist: {
-    name: 'Heurist (You will need to provide an API key. Get free API credits at https://dev-api-form.heurist.ai/ with referral code: "genlayer"):',
+  heuristai: {
+    name: "Heurist",
+    hint: '(You will need to provide an API key. Get free API credits at https://dev-api-form.heurist.ai/ with referral code: "genlayer")',
     envVar: "HEURISTAIAPIKEY",
-    cliOptionValue: "heurist",
+    cliOptionValue: "heuristai",
   },
 };

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -10,6 +10,7 @@ import {
   STARTING_TIMEOUT_WAIT_CYLCE,
   STARTING_TIMEOUT_ATTEMPTS,
   AI_PROVIDERS_CONFIG,
+  AiProviders,
 } from "@/lib/config/simulator";
 import {
   checkCommand,
@@ -190,17 +191,23 @@ export async function initializeDatabase(): Promise<InitializeDatabaseResultType
   return {createResponse, tablesResponse};
 }
 
-export function createRandomValidators(numValidators: number): Promise<any> {
-  return rpcClient.request({method: "create_random_validators", params: [numValidators, 1, 10]});
+export function createRandomValidators(numValidators: number, llmProviders: AiProviders[]): Promise<any> {
+  return rpcClient.request({
+    method: "create_random_validators",
+    params: [numValidators, 1, 10, llmProviders],
+  });
 }
 
 export function deleteAllValidators(): Promise<any> {
   return rpcClient.request({method: "delete_all_validators", params: []});
 }
 
-export function getAiProvidersOptions(): Array<{name: string; value: string}> {
+export function getAiProvidersOptions(withHint: boolean = true): Array<{name: string; value: string}> {
   return Object.values(AI_PROVIDERS_CONFIG).map(providerConfig => {
-    return {name: providerConfig.name, value: providerConfig.cliOptionValue};
+    return {
+      name: `${providerConfig.name}${withHint ? ` ${providerConfig.hint}` : ""}`,
+      value: providerConfig.cliOptionValue,
+    };
   });
 }
 

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -160,7 +160,8 @@ export async function waitForSimulatorToBeReady(
     }
   } catch (error: any) {
     if (
-      (error.message.includes("ECONNRESET") ||
+      (error.name === "FetchError" ||
+        error.message.includes("ECONNRESET") ||
         error.message.includes("ECONNREFUSED") ||
         error.message.includes("socket hang up")) &&
       retries > 0


### PR DESCRIPTION
When starting the simulator with the validators restart option (`genlayer up --reset-validators`) the CLI ask for the providers to be used.