### PR TITLE
fix: response check

### DIFF
--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -180,7 +180,7 @@ export class SimulatorService implements ISimulatorService {
       const response = await rpcClient.request({method: "ping", params: []});
 
       //Compatibility with current simulator version
-      if (response && (response.result.status === "OK" || response.result.data.status === "OK")) {
+      if (response && (response.result === "OK" || response.result.status === "OK" || response.result.data.status === "OK")) {
         return {initialized: true};
       }
       if (retries > 0) {


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #77 

# What

<!-- Describe the changes you made. -->

- changed the response check .

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- see issue for the reason.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- When running genlayer up the request response looks like this:
{
  id: '778dfa8e-9107-4de6-8c15-71232fa07506',
  jsonrpc: '2.0',
  result: 'OK'
}
It does not contain status or data.status.
- I did not run any existing tests.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
run the code