### PR TITLE
fix: changing linux command to fix display issue

### DIFF
--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -4,7 +4,7 @@ export const DOCKER_IMAGES_AND_CONTAINERS_NAME_PREFIX = "genlayer-simulator-";
 export const DEFAULT_RUN_SIMULATOR_COMMAND = (simulatorLocation: string) => ({
   darwin: `osascript -e 'tell application "Terminal" to do script "cd ${simulatorLocation} && docker compose build && docker compose up"'`,
   win32: `start cmd.exe /c "cd /d ${simulatorLocation} && docker compose build && docker compose up && pause"`,
-  linux: `x-terminal-emulator -e bash -c 'cd ${simulatorLocation} && docker compose build && docker compose up; echo "Press enter to exit"; read'`,
+  linux: `nohup bash -c 'cd ${simulatorLocation} && docker compose build && docker compose up -d'`,
 });
 export const DEFAULT_PULL_OLLAMA_COMMAND = (simulatorLocation: string) => ({
   darwin: `cd ${simulatorLocation} && docker exec ollama ollama pull llama3`,

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -221,7 +221,7 @@ export class SimulatorService implements ISimulatorService {
       const response = await rpcClient.request({method: "ping", params: []});
 
       //Compatibility with current simulator version
-      if (response?.result?.status === "OK" || response?.result?.data?.status === "OK") {
+      if (response?.result === "OK" || response?.result?.status === "OK" || response?.result?.data?.status === "OK") {
         return { initialized: true };
       }
       if (retries > 0) {

--- a/tests/services/simulator.test.ts
+++ b/tests/services/simulator.test.ts
@@ -104,15 +104,22 @@ describe("SimulatorService - Basic Tests", () => {
     expect(fs.existsSync).toHaveBeenCalled();
   });
 
-  test("should return initialized true when simulator responds with OK", async () => {
+  test("should return initialized true when simulator responds with OK (result.status = OK)", async () => {
     vi.mocked(rpcClient.request).mockResolvedValueOnce({ result: {status: 'OK'} });
     const result = await simulatorService.waitForSimulatorToBeReady(STARTING_TIMEOUT_ATTEMPTS);
     expect(result).toEqual({ initialized: true });
     expect(rpcClient.request).toHaveBeenCalledWith({ method: "ping", params: [] });
   });
 
-  test("should return initialized true when simulator responds with OK (different json structure)", async () => {
+  test("should return initialized true when simulator responds with OK (result.data.status = OK)", async () => {
     vi.mocked(rpcClient.request).mockResolvedValueOnce({ result: {data: {status: 'OK'}} });
+    const result = await simulatorService.waitForSimulatorToBeReady(STARTING_TIMEOUT_ATTEMPTS);
+    expect(result).toEqual({ initialized: true });
+    expect(rpcClient.request).toHaveBeenCalledWith({ method: "ping", params: [] });
+  });
+
+  test("should return initialized true when simulator responds with OK (result = OK)", async () => {
+    vi.mocked(rpcClient.request).mockResolvedValueOnce({ result: 'OK' });
     const result = await simulatorService.waitForSimulatorToBeReady(STARTING_TIMEOUT_ATTEMPTS);
     expect(result).toEqual({ initialized: true });
     expect(rpcClient.request).toHaveBeenCalledWith({ method: "ping", params: [] });


### PR DESCRIPTION
Fixed a bug in the Linux simulator start command where x-terminal-emulator required a display, causing issues when accessed via SSH without a display environment. Replaced x-terminal-emulator with nohup and docker compose up -d, enabling the simulator to run in detached mode in headless environments, eliminating the dependency on a display and improving SSH compatibility.