### PR TITLE
feat: adding headless option to cli

### DIFF
--- a/src/commands/general/index.ts
+++ b/src/commands/general/index.ts
@@ -12,6 +12,7 @@ export function initializeGeneralCommands(program: Command) {
     .option("--numValidators <numValidators>", "Number of validators", "5")
     .option("--branch <branch>", "Branch", "main")
     .option("--location <folder>", "Location where it will be installed", process.cwd())
+    .option("--headless", "Headless mode", false)
     .action((options: InitActionOptions) => initAction(options, simulatorService));
 
   program
@@ -21,6 +22,7 @@ export function initializeGeneralCommands(program: Command) {
     .option("--numValidators <numValidators>", "Number of validators", "5")
     .option("--branch <branch>", "Branch", "main")
     .option("--location <folder>", "Location where it will be installed", process.cwd())
+    .option("--headless", "Headless mode", false)
     .action((options: StartActionOptions) => startAction(options, simulatorService));
 
   return program;

--- a/src/commands/general/init.ts
+++ b/src/commands/general/init.ts
@@ -39,7 +39,7 @@ function getVersionErrorMessage({docker, node}: Record<string, string>): string 
 
 export async function initAction(options: InitActionOptions, simulatorService: ISimulatorService) {
   simulatorService.setSimulatorLocation(options.location);
-  simulatorService.setProfile(options.headless);
+  simulatorService.setComposeOptions(options.headless);
 
   // Check if requirements are installed
   try {
@@ -230,8 +230,9 @@ export async function initAction(options: InitActionOptions, simulatorService: I
     `GenLayer simulator initialized successfully! Go to ${simulatorService.getFrontendUrl()} in your browser to access it.`,
   );
   try {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    simulatorService.openFrontend();
+    if(!options.headless){
+      await simulatorService.openFrontend();
+    }
   } catch (error) {
     console.error(error);
   }

--- a/src/commands/general/init.ts
+++ b/src/commands/general/init.ts
@@ -6,7 +6,7 @@ export interface InitActionOptions {
   numValidators: number;
   branch: string;
   location: string;
-
+  headless: boolean;
 }
 
 function getRequirementsErrorMessage({git, docker}: Record<string, boolean>): string {
@@ -38,9 +38,8 @@ function getVersionErrorMessage({docker, node}: Record<string, string>): string 
 }
 
 export async function initAction(options: InitActionOptions, simulatorService: ISimulatorService) {
-  // Update simulator location with user input
   simulatorService.setSimulatorLocation(options.location);
-
+  simulatorService.setProfile(options.headless);
 
   // Check if requirements are installed
   try {

--- a/src/commands/general/start.ts
+++ b/src/commands/general/start.ts
@@ -102,7 +102,9 @@ export async function startAction(options: StartActionOptions, simulatorService:
     `GenLayer simulator initialized successfully! Go to ${simulatorService.getFrontendUrl()} in your browser to access it.`,
   );
   try {
-    await simulatorService.openFrontend();
+    if(!headless) {
+      await simulatorService.openFrontend();
+    }
 
   } catch (error) {
     console.error(error);

--- a/src/commands/general/start.ts
+++ b/src/commands/general/start.ts
@@ -13,7 +13,7 @@ export interface StartActionOptions {
 export async function startAction(options: StartActionOptions, simulatorService: ISimulatorService) {
   const {resetValidators, numValidators, branch, location, headless} = options;
   // Update simulator location with user input
-  simulatorService.setProfile(headless);
+  simulatorService.setComposeOptions(headless);
   simulatorService.setSimulatorLocation(location);
 
 

--- a/src/commands/general/start.ts
+++ b/src/commands/general/start.ts
@@ -7,11 +7,13 @@ export interface StartActionOptions {
   numValidators: number;
   branch: string;
   location: string;
+  headless: boolean;
 }
 
 export async function startAction(options: StartActionOptions, simulatorService: ISimulatorService) {
-  const {resetValidators, numValidators, branch, location} = options;
+  const {resetValidators, numValidators, branch, location, headless} = options;
   // Update simulator location with user input
+  simulatorService.setProfile(headless);
   simulatorService.setSimulatorLocation(location);
 
 

--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -1,10 +1,10 @@
 export const DEFAULT_JSON_RPC_URL = "http://localhost:4000/api";
 export const DEFAULT_REPO_GH_URL = "https://github.com/yeagerai/genlayer-simulator.git";
 export const DOCKER_IMAGES_AND_CONTAINERS_NAME_PREFIX = "genlayer-simulator-";
-export const DEFAULT_RUN_SIMULATOR_COMMAND = (simulatorLocation: string) => ({
-  darwin: `osascript -e 'tell application "Terminal" to do script "cd ${simulatorLocation} && docker compose build && docker compose up"'`,
-  win32: `start cmd.exe /c "cd /d ${simulatorLocation} && docker compose build && docker compose up && pause"`,
-  linux: `nohup bash -c 'cd ${simulatorLocation} && docker compose build && docker compose up -d'`,
+export const DEFAULT_RUN_SIMULATOR_COMMAND = (simulatorLocation: string, profile: string) => ({
+  darwin: `osascript -e 'tell application "Terminal" to do script "cd ${simulatorLocation} && docker compose build && docker compose ${profile} up"'`,
+  win32: `start cmd.exe /c "cd /d ${simulatorLocation} && docker compose build && docker compose ${profile} up && pause"`,
+  linux: `nohup bash -c 'cd ${simulatorLocation} && docker compose build && docker compose ${profile} up -d'`,
 });
 export const DEFAULT_PULL_OLLAMA_COMMAND = (simulatorLocation: string) => ({
   darwin: `cd ${simulatorLocation} && docker exec ollama ollama pull llama3`,

--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -1,10 +1,10 @@
 export const DEFAULT_JSON_RPC_URL = "http://localhost:4000/api";
 export const DEFAULT_REPO_GH_URL = "https://github.com/yeagerai/genlayer-simulator.git";
 export const DOCKER_IMAGES_AND_CONTAINERS_NAME_PREFIX = "genlayer-simulator-";
-export const DEFAULT_RUN_SIMULATOR_COMMAND = (simulatorLocation: string, profile: string) => ({
-  darwin: `osascript -e 'tell application "Terminal" to do script "cd ${simulatorLocation} && docker compose build && docker compose ${profile} up"'`,
-  win32: `start cmd.exe /c "cd /d ${simulatorLocation} && docker compose build && docker compose ${profile} up && pause"`,
-  linux: `nohup bash -c 'cd ${simulatorLocation} && docker compose build && docker compose ${profile} up -d'`,
+export const DEFAULT_RUN_SIMULATOR_COMMAND = (simulatorLocation: string, options: string) => ({
+  darwin: `osascript -e 'tell application "Terminal" to do script "cd ${simulatorLocation} && docker compose build && docker compose up ${options}"'`,
+  win32: `start cmd.exe /c "cd /d ${simulatorLocation} && docker compose build && docker compose up && pause ${options}"`,
+  linux: `nohup bash -c 'cd ${simulatorLocation} && docker compose build && docker compose up -d ${options}'`,
 });
 export const DEFAULT_PULL_OLLAMA_COMMAND = (simulatorLocation: string) => ({
   darwin: `cd ${simulatorLocation} && docker exec ollama ollama pull llama3`,

--- a/src/lib/interfaces/ISimulatorService.ts
+++ b/src/lib/interfaces/ISimulatorService.ts
@@ -3,8 +3,8 @@ import {AiProviders} from "../config/simulator";
 export interface ISimulatorService {
   setSimulatorLocation(location: string): void;
   getSimulatorLocation(): string;
-  setProfile(headless: boolean): void;
-  getProfile(): string;
+  setComposeOptions(headless: boolean): void;
+  getComposeOptions(): string;
   checkInstallRequirements(): Promise<Record<string, boolean>>;
   checkVersionRequirements(): Promise<Record<string, string>>;
   downloadSimulator(branch?: string): Promise<DownloadSimulatorResultType>;

--- a/src/lib/interfaces/ISimulatorService.ts
+++ b/src/lib/interfaces/ISimulatorService.ts
@@ -3,6 +3,8 @@ import {AiProviders} from "../config/simulator";
 export interface ISimulatorService {
   setSimulatorLocation(location: string): void;
   getSimulatorLocation(): string;
+  setProfile(headless: boolean): void;
+  getProfile(): string;
   checkInstallRequirements(): Promise<Record<string, boolean>>;
   checkVersionRequirements(): Promise<Record<string, string>>;
   downloadSimulator(branch?: string): Promise<DownloadSimulatorResultType>;

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -41,10 +41,12 @@ function sleep(millliseconds: number): Promise<void> {
 }
 
 export class SimulatorService implements ISimulatorService {
+  private profile: string
   public simulatorLocation: string;
 
   constructor() {
     this.simulatorLocation = "";
+    this.profile = "";
   }
 
   public setSimulatorLocation(location: string): void {
@@ -53,6 +55,14 @@ export class SimulatorService implements ISimulatorService {
 
   public getSimulatorLocation(): string {
     return this.simulatorLocation;
+  }
+
+  public setProfile(headless: boolean): void {
+    this.profile = headless ? '' : '--profile frontend';
+  }
+
+  public getProfile(): string {
+    return this.profile;
   }
 
   private readEnvConfigValue(key: string): string {
@@ -209,7 +219,7 @@ export class SimulatorService implements ISimulatorService {
   }
 
   public runSimulator(): Promise<{stdout: string; stderr: string}> {
-    const commandsByPlatform = DEFAULT_RUN_SIMULATOR_COMMAND(this.simulatorLocation);
+    const commandsByPlatform = DEFAULT_RUN_SIMULATOR_COMMAND(this.simulatorLocation, this.getProfile());
     return executeCommand(commandsByPlatform);
   }
 

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -41,12 +41,12 @@ function sleep(millliseconds: number): Promise<void> {
 }
 
 export class SimulatorService implements ISimulatorService {
-  private profile: string
+  private composeOptions: string
   public simulatorLocation: string;
 
   constructor() {
     this.simulatorLocation = "";
-    this.profile = "";
+    this.composeOptions = "";
   }
 
   public setSimulatorLocation(location: string): void {
@@ -57,12 +57,12 @@ export class SimulatorService implements ISimulatorService {
     return this.simulatorLocation;
   }
 
-  public setProfile(headless: boolean): void {
-    this.profile = headless ? '' : '--profile frontend';
+  public setComposeOptions(headless: boolean): void {
+    this.composeOptions = headless ? '--scale frontend=0' : '';
   }
 
-  public getProfile(): string {
-    return this.profile;
+  public getComposeOptions(): string {
+    return this.composeOptions;
   }
 
   private readEnvConfigValue(key: string): string {
@@ -219,7 +219,7 @@ export class SimulatorService implements ISimulatorService {
   }
 
   public runSimulator(): Promise<{stdout: string; stderr: string}> {
-    const commandsByPlatform = DEFAULT_RUN_SIMULATOR_COMMAND(this.simulatorLocation, this.getProfile());
+    const commandsByPlatform = DEFAULT_RUN_SIMULATOR_COMMAND(this.simulatorLocation, this.getComposeOptions());
     return executeCommand(commandsByPlatform);
   }
 

--- a/tests/actions/init.test.ts
+++ b/tests/actions/init.test.ts
@@ -7,7 +7,7 @@ import {mkdtempSync} from "fs";
 import {join} from "path";
 
 const tempDir = mkdtempSync(join(tmpdir(), "test-initAction-"));
-const defaultActionOptions = { numValidators: 5, branch: "main", location: tempDir };
+const defaultActionOptions = { numValidators: 5, branch: "main", location: tempDir, headless: false };
 
 describe("init action", () => {
   let error: ReturnType<any>;
@@ -49,7 +49,6 @@ describe("init action", () => {
     simServDeleteAllValidators = vi.spyOn(simulatorService, "deleteAllValidators");
     simServCreateRandomValidators = vi.spyOn(simulatorService, "createRandomValidators");
     simServOpenFrontend = vi.spyOn(simulatorService, "openFrontend");
-    simGetSimulatorUrl = vi.spyOn(simulatorService, "getFrontendUrl")
   });
 
   afterEach(() => {

--- a/tests/actions/init.test.ts
+++ b/tests/actions/init.test.ts
@@ -49,6 +49,7 @@ describe("init action", () => {
     simServDeleteAllValidators = vi.spyOn(simulatorService, "deleteAllValidators");
     simServCreateRandomValidators = vi.spyOn(simulatorService, "createRandomValidators");
     simServOpenFrontend = vi.spyOn(simulatorService, "openFrontend");
+    simGetSimulatorUrl = vi.spyOn(simulatorService, "getFrontendUrl")
   });
 
   afterEach(() => {

--- a/tests/actions/start.test.ts
+++ b/tests/actions/start.test.ts
@@ -30,7 +30,7 @@ describe("startAction - Additional Tests", () => {
       createRandomValidators: vi.fn().mockResolvedValue(undefined),
       openFrontend: vi.fn().mockResolvedValue(undefined),
       setSimulatorLocation: vi.fn().mockResolvedValue(undefined),
-      setProfile: vi.fn(),
+      setComposeOptions: vi.fn(),
       getAiProvidersOptions: vi.fn(() => [
         { name: "Provider A", value: "providerA" },
         { name: "Provider B", value: "providerB" },

--- a/tests/actions/start.test.ts
+++ b/tests/actions/start.test.ts
@@ -13,7 +13,8 @@ describe("startAction - Additional Tests", () => {
     resetValidators: false,
     numValidators: 5,
     branch: "main",
-    location: ''
+    location: '',
+    headless: false,
   };
 
   beforeEach(() => {
@@ -29,6 +30,7 @@ describe("startAction - Additional Tests", () => {
       createRandomValidators: vi.fn().mockResolvedValue(undefined),
       openFrontend: vi.fn().mockResolvedValue(undefined),
       setSimulatorLocation: vi.fn().mockResolvedValue(undefined),
+      setProfile: vi.fn(),
       getAiProvidersOptions: vi.fn(() => [
         { name: "Provider A", value: "providerA" },
         { name: "Provider B", value: "providerB" },

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -71,6 +71,6 @@ describe("init command", () => {
   test("action is called", async () => {
     program.parse(["node", "test", "init"]);
     expect(action).toHaveBeenCalledTimes(1);
-    expect(action).toHaveBeenCalledWith({ numValidators: "5", branch: "main", location: process.cwd() });
+    expect(action).toHaveBeenCalledWith({ numValidators: "5", branch: "main", location: process.cwd(), headless: false });
   });
 });

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -2,6 +2,9 @@ import { Command } from "commander";
 import { vi, describe, beforeEach, afterEach, test, expect } from "vitest";
 import { initializeGeneralCommands } from "../../src/commands/general";
 import { getCommand, getCommandOption } from "../utils";
+import simulatorService from  '../../src/lib/services/simulator'
+
+const openFrontendSpy = vi.spyOn(simulatorService, "openFrontend");
 
 vi.mock("inquirer", () => ({
   prompt: vi.fn(() => {}),
@@ -78,5 +81,6 @@ describe("init command", () => {
     program.parse(["node", "test", "init", "--headless"]);
     expect(action).toHaveBeenCalledTimes(1);
     expect(action).toHaveBeenCalledWith({ numValidators: "5", branch: "main", location: process.cwd(), headless: true });
+    expect(openFrontendSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -73,4 +73,10 @@ describe("init command", () => {
     expect(action).toHaveBeenCalledTimes(1);
     expect(action).toHaveBeenCalledWith({ numValidators: "5", branch: "main", location: process.cwd(), headless: false });
   });
+
+  test("option --headless is accepted", async () => {
+    program.parse(["node", "test", "init", "--headless"]);
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(action).toHaveBeenCalledWith({ numValidators: "5", branch: "main", location: process.cwd(), headless: true });
+  });
 });

--- a/tests/commands/up.test.ts
+++ b/tests/commands/up.test.ts
@@ -69,7 +69,7 @@ describe("up command", () => {
   test("action is called with default options", async () => {
     program.parse(["node", "test", "up"]);
     expect(action).toHaveBeenCalledTimes(1);
-    expect(action).toHaveBeenCalledWith({ resetValidators: false, numValidators: "5", branch: "main", location: process.cwd() });
+    expect(action).toHaveBeenCalledWith({ resetValidators: false, numValidators: "5", branch: "main", location: process.cwd(), headless: false });
   });
 
   test("action is called with custom options", async () => {
@@ -82,6 +82,8 @@ describe("up command", () => {
       "10",
       "--branch",
       "development",
+      "--headless",
+      "true"
     ]);
     expect(action).toHaveBeenCalledTimes(1);
     expect(action).toHaveBeenCalledWith({
@@ -89,6 +91,7 @@ describe("up command", () => {
       numValidators: "10",
       branch: "development",
       location: process.cwd(),
+      headless: true,
     });
   });
 });

--- a/tests/commands/up.test.ts
+++ b/tests/commands/up.test.ts
@@ -2,6 +2,9 @@ import { Command } from "commander";
 import { vi, describe, beforeEach, afterEach, test, expect } from "vitest";
 import { initializeGeneralCommands } from "../../src/commands/general";
 import { getCommand, getCommandOption } from "../utils";
+import simulatorService from  '../../src/lib/services/simulator'
+
+const openFrontendSpy = vi.spyOn(simulatorService, "openFrontend");
 
 const action = vi.fn();
 
@@ -93,5 +96,6 @@ describe("up command", () => {
       location: process.cwd(),
       headless: true,
     });
+    expect(openFrontendSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/services/simulator.test.ts
+++ b/tests/services/simulator.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../../src/lib/config/simulator";
 import { rpcClient } from "../../src/lib/clients/jsonRpcClient";
 import * as semver from "semver";
+import {getCommandOption} from "@@/tests/utils";
 
 
 vi.mock("fs");
@@ -156,6 +157,19 @@ describe("SimulatorService - Basic Tests", () => {
     });
     const result = await simulatorService.runSimulator();
     const expectedCommand = DEFAULT_RUN_SIMULATOR_COMMAND("/mock/home/genlayer-simulator", '');
+    expect(executeCommand).toHaveBeenCalledWith(expectedCommand);
+    expect(result).toEqual({ stdout: "Simulator started", stderr: "" });
+  });
+
+  test("should execute the correct run simulator command based on headless option", async () => {
+    (executeCommand as Mock).mockResolvedValue({
+      stdout: "Simulator started",
+      stderr: "",
+    });
+    simulatorService.setComposeOptions(true)
+    const commandOption = simulatorService.getComposeOptions();
+    const result = await simulatorService.runSimulator();
+    const expectedCommand = DEFAULT_RUN_SIMULATOR_COMMAND("/mock/home/genlayer-simulator", commandOption);
     expect(executeCommand).toHaveBeenCalledWith(expectedCommand);
     expect(result).toEqual({ stdout: "Simulator started", stderr: "" });
   });

--- a/tests/services/simulator.test.ts
+++ b/tests/services/simulator.test.ts
@@ -155,7 +155,7 @@ describe("SimulatorService - Basic Tests", () => {
       stderr: "",
     });
     const result = await simulatorService.runSimulator();
-    const expectedCommand = DEFAULT_RUN_SIMULATOR_COMMAND("/mock/home/genlayer-simulator");
+    const expectedCommand = DEFAULT_RUN_SIMULATOR_COMMAND("/mock/home/genlayer-simulator", '');
     expect(executeCommand).toHaveBeenCalledWith(expectedCommand);
     expect(result).toEqual({ stdout: "Simulator started", stderr: "" });
   });


### PR DESCRIPTION
### Feature: Add `headless` Option to CLI

This PR introduces a new `headless` option for the CLI, which enables backend-only operation by excluding the frontend service. Specifically, when the `headless` option is specified:

- The `frontend` service will not start up in Docker Compose.
- The frontend interface will not automatically open.

This addition preserves current functionality when `headless` is not used, allowing users to run either full-stack or backend-only setups as needed.
