### PR TITLE
fix: removing paid feature

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,8 +13,7 @@
       "matchUpdateTypes": [
         "minor",
         "patch"
-      ],
-      "matchConfidence": ["very high", "high"]
+      ]
     }
   ]
 }


### PR DESCRIPTION
To leverage the matchConfidence feature in Renovate, we need to integrate a Mend API key, which requires a paid Mend subscription. This feature is only available in the paid version of Mend Renovate.