### PR TITLE
feat: new reset db option

### DIFF
--- a/src/commands/general/index.ts
+++ b/src/commands/general/index.ts
@@ -13,6 +13,7 @@ export function initializeGeneralCommands(program: Command) {
     .option("--branch <branch>", "Branch", "main")
     .option("--location <folder>", "Location where it will be installed", process.cwd())
     .option("--headless", "Headless mode", false)
+    .option("--reset-db", "Reset Database", false)
     .action((options: InitActionOptions) => initAction(options, simulatorService));
 
   program
@@ -23,6 +24,7 @@ export function initializeGeneralCommands(program: Command) {
     .option("--branch <branch>", "Branch", "main")
     .option("--location <folder>", "Location where it will be installed", process.cwd())
     .option("--headless", "Headless mode", false)
+    .option("--reset-db", "Reset Database", false)
     .action((options: StartActionOptions) => startAction(options, simulatorService));
 
   return program;

--- a/src/commands/general/init.ts
+++ b/src/commands/general/init.ts
@@ -7,6 +7,7 @@ export interface InitActionOptions {
   branch: string;
   location: string;
   headless: boolean;
+  resetDb: boolean;
 }
 
 function getRequirementsErrorMessage({git, docker}: Record<string, boolean>): string {
@@ -223,6 +224,10 @@ export async function initAction(options: InitActionOptions, simulatorService: I
     console.error("Unable to initialize the validators.");
     console.error(error);
     return;
+  }
+
+  if(options.resetDb){
+    await simulatorService.cleanDatabase()
   }
 
   // Simulator ready

--- a/src/commands/general/start.ts
+++ b/src/commands/general/start.ts
@@ -8,10 +8,11 @@ export interface StartActionOptions {
   branch: string;
   location: string;
   headless: boolean;
+  resetDb: boolean
 }
 
 export async function startAction(options: StartActionOptions, simulatorService: ISimulatorService) {
-  const {resetValidators, numValidators, branch, location, headless} = options;
+  const {resetValidators, numValidators, branch, location, headless, resetDb} = options;
   // Update simulator location with user input
   simulatorService.setComposeOptions(headless);
   simulatorService.setSimulatorLocation(location);
@@ -58,6 +59,10 @@ export async function startAction(options: StartActionOptions, simulatorService:
   } catch (error) {
     console.error(error);
     return;
+  }
+
+  if(resetDb){
+    await simulatorService.cleanDatabase()
   }
 
   if (resetValidators) {

--- a/src/lib/interfaces/ISimulatorService.ts
+++ b/src/lib/interfaces/ISimulatorService.ts
@@ -20,6 +20,7 @@ export interface ISimulatorService {
   openFrontend(): Promise<boolean>;
   resetDockerContainers(): Promise<boolean>;
   resetDockerImages(): Promise<boolean>;
+  cleanDatabase(): Promise<boolean>;
 }
 
 export type DownloadSimulatorResultType = {

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -317,6 +317,17 @@ export class SimulatorService implements ISimulatorService {
 
     return true;
   }
+
+  public async cleanDatabase(): Promise<boolean> {
+
+    try {
+      await rpcClient.request({method: "sim_clearDbTables", params: [['current_state', 'transactions']]});
+    }catch (error) {
+      console.error(error);
+    }
+    return true;
+  }
+
 }
 
 export default new SimulatorService();

--- a/tests/actions/init.test.ts
+++ b/tests/actions/init.test.ts
@@ -7,7 +7,7 @@ import {mkdtempSync} from "fs";
 import {join} from "path";
 
 const tempDir = mkdtempSync(join(tmpdir(), "test-initAction-"));
-const defaultActionOptions = { numValidators: 5, branch: "main", location: tempDir, headless: false };
+const defaultActionOptions = { numValidators: 5, branch: "main", location: tempDir, headless: false, resetDb: false };
 
 describe("init action", () => {
   let error: ReturnType<any>;
@@ -188,7 +188,7 @@ describe("init action", () => {
     );
   });
 
-  test("should open the frontend if everything went well (headless mode)", async () => {
+  test("should open the frontend if everything went well (custom options)", async () => {
     inquirerPrompt.mockResolvedValue({
       confirmReset: true,
       confirmDownload: true,
@@ -211,7 +211,7 @@ describe("init action", () => {
     simServResetDockerContainers.mockResolvedValue(true);
     simServResetDockerImages.mockResolvedValue(true);
 
-    await initAction({...defaultActionOptions, headless: true}, simulatorService);
+    await initAction({...defaultActionOptions, headless: true, resetDb: true}, simulatorService);
 
     expect(log).toHaveBeenCalledWith(
       `GenLayer simulator initialized successfully! `
@@ -235,6 +235,8 @@ describe("init action", () => {
     simServWaitForSimulator.mockResolvedValue({ initialized: true });
     simServPullOllamaModel.mockResolvedValue(true);
     simServDeleteAllValidators.mockResolvedValue(true);
+    simServResetDockerContainers.mockResolvedValue(true);
+    simServResetDockerImages.mockResolvedValue(true);
     simServCreateRandomValidators.mockRejectedValue();
     simServOpenFrontend.mockResolvedValue(true);
 

--- a/tests/actions/start.test.ts
+++ b/tests/actions/start.test.ts
@@ -15,6 +15,7 @@ describe("startAction - Additional Tests", () => {
     branch: "main",
     location: '',
     headless: false,
+    resetDb: false
   };
 
   beforeEach(() => {
@@ -36,6 +37,7 @@ describe("startAction - Additional Tests", () => {
         { name: "Provider B", value: "providerB" },
       ]),
       getFrontendUrl: vi.fn(() => "http://localhost:8080"),
+      cleanDatabase: vi.fn().mockResolvedValue(undefined),
     } as unknown as ISimulatorService;
   });
 
@@ -59,8 +61,8 @@ describe("startAction - Additional Tests", () => {
     expect(simulatorService.openFrontend).toHaveBeenCalled();
   });
 
-  test("runs successfully with default options and keeps existing validators (headless)", async () => {
-    await startAction({...defaultOptions, headless: true}, simulatorService);
+  test("runs successfully with custom options and keeps existing validators", async () => {
+    await startAction({...defaultOptions, headless: true, resetDb: true}, simulatorService);
 
     expect(simulatorService.updateSimulator).toHaveBeenCalledWith("main");
     expect(simulatorService.runSimulator).toHaveBeenCalled();

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -5,6 +5,13 @@ import { getCommand, getCommandOption } from "../utils";
 import simulatorService from  '../../src/lib/services/simulator'
 
 const openFrontendSpy = vi.spyOn(simulatorService, "openFrontend");
+const defaultOptions = {
+  numValidators: "5",
+  branch: "main",
+  location: process.cwd(),
+  headless: false,
+  resetDb: false
+}
 
 vi.mock("inquirer", () => ({
   prompt: vi.fn(() => {}),
@@ -74,13 +81,13 @@ describe("init command", () => {
   test("action is called", async () => {
     program.parse(["node", "test", "init"]);
     expect(action).toHaveBeenCalledTimes(1);
-    expect(action).toHaveBeenCalledWith({ numValidators: "5", branch: "main", location: process.cwd(), headless: false });
+    expect(action).toHaveBeenCalledWith(defaultOptions);
   });
 
   test("option --headless is accepted", async () => {
     program.parse(["node", "test", "init", "--headless"]);
     expect(action).toHaveBeenCalledTimes(1);
-    expect(action).toHaveBeenCalledWith({ numValidators: "5", branch: "main", location: process.cwd(), headless: true });
+    expect(action).toHaveBeenCalledWith({...defaultOptions, headless: true});
     expect(openFrontendSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/commands/up.test.ts
+++ b/tests/commands/up.test.ts
@@ -7,6 +7,14 @@ import simulatorService from  '../../src/lib/services/simulator'
 const openFrontendSpy = vi.spyOn(simulatorService, "openFrontend");
 
 const action = vi.fn();
+const defaultOptions = {
+  resetValidators: false,
+  numValidators: "5",
+  branch: "main",
+  location: process.cwd(),
+  headless: false ,
+  resetDb: false
+}
 
 describe("up command", () => {
   let upCommand: Command;
@@ -72,7 +80,7 @@ describe("up command", () => {
   test("action is called with default options", async () => {
     program.parse(["node", "test", "up"]);
     expect(action).toHaveBeenCalledTimes(1);
-    expect(action).toHaveBeenCalledWith({ resetValidators: false, numValidators: "5", branch: "main", location: process.cwd(), headless: false });
+    expect(action).toHaveBeenCalledWith(defaultOptions);
   });
 
   test("action is called with custom options", async () => {
@@ -86,16 +94,12 @@ describe("up command", () => {
       "--branch",
       "development",
       "--headless",
+      "true",
+      "--reset-db",
       "true"
     ]);
     expect(action).toHaveBeenCalledTimes(1);
-    expect(action).toHaveBeenCalledWith({
-      resetValidators: true,
-      numValidators: "10",
-      branch: "development",
-      location: process.cwd(),
-      headless: true,
-    });
+    expect(action).toHaveBeenCalledWith({...defaultOptions, headless: true, branch: 'development', numValidators: '10', resetValidators: true, resetDb: true});
     expect(openFrontendSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/services/simulator.test.ts
+++ b/tests/services/simulator.test.ts
@@ -281,6 +281,12 @@ describe("SimulatorService - Basic Tests", () => {
     expect(simulatorService.getAiProvidersOptions(false)).toEqual(expect.any(Array));
   });
 
+  test("clean simulator should success", async () => {
+    vi.mocked(rpcClient.request).mockResolvedValueOnce('Success');
+    await expect(simulatorService.cleanDatabase).not.toThrow();
+    expect(rpcClient.request).toHaveBeenCalledWith({ method: "sim_clearDbTables", params: [['current_state', 'transactions']] });
+  });
+
 });
 describe("SimulatorService - Docker Tests", () => {
   let mockExec: Mock;


### PR DESCRIPTION
## Description

- Introduced `--reset-db` flag for the `init` and `up` commands to clear `current_state` and `transactions` tables via RPC.
- Implemented `cleanDatabase` method for handling the database reset.
- Enables an optional clean state for initialization or startup.

### Evidence:

<img width="566" alt="Screenshot 2024-11-19 at 20 57 07" src="https://github.com/user-attachments/assets/1bf931b0-be8a-4c19-a158-d9322dec5f43">



