### PR TITLE
fix: fixing bug when the command does not exist

### DIFF
--- a/src/lib/clients/system.ts
+++ b/src/lib/clients/system.ts
@@ -6,9 +6,12 @@ import {RunningPlatform, AVAILABLE_PLATFORMS} from "../config/simulator";
 import {MissingRequirementError} from "../errors/missingRequirement";
 
 export async function checkCommand(command: string, toolName: string): Promise<void> {
-  const {stderr} = await util.promisify(exec)(command);
-  if (stderr) {
-    throw new MissingRequirementError(toolName);
+  try {
+    await util.promisify(exec)(command);
+  }catch (error:any) {
+    if (error.stderr) {
+      throw new MissingRequirementError(toolName);
+    }
   }
 }
 

--- a/tests/actions/init.test.ts
+++ b/tests/actions/init.test.ts
@@ -237,6 +237,8 @@ describe("init action", () => {
     simServDeleteAllValidators.mockResolvedValue(true);
     simServCreateRandomValidators.mockRejectedValue();
     simServOpenFrontend.mockResolvedValue(true);
+    simServResetDockerContainers.mockResolvedValue(true);
+    simServResetDockerImages.mockResolvedValue(true);
 
     await initAction({...defaultActionOptions, headless: true}, simulatorService);
 

--- a/tests/libs/system.test.ts
+++ b/tests/libs/system.test.ts
@@ -88,7 +88,7 @@ describe("System Functions - Error Paths", () => {
   });
 
   test("checkCommand returns false if the command does not exist", async () => {
-    vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.resolve({
+    vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.reject({
       stdout: "",
       stderr: "command not found"
     }));


### PR DESCRIPTION
It now logs the correct message when the command does not exist.

Before:

<img width="545" alt="Screenshot 2024-11-21 at 20 03 24" src="https://github.com/user-attachments/assets/4a3d9e6a-f384-4014-8fa0-22895cfb87b3">


Now:
<img width="557" alt="Screenshot 2024-11-21 at 20 32 16" src="https://github.com/user-attachments/assets/3b2869ae-3cb5-442a-927c-6c52244bfde9">
