### PR TITLE
feat: chack cli version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "inquirer": "^9.2.19",
         "node-fetch": "^2.7.0",
         "open": "^10.1.0",
+        "update-check": "^1.5.4",
         "uuid": "^9.0.1",
         "vitest": "^2.1.4"
       },
@@ -2769,7 +2770,6 @@
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -5509,7 +5509,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6287,7 +6286,6 @@
     },
     "node_modules/rc": {
       "version": "1.2.8",
-      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -6301,12 +6299,10 @@
     },
     "node_modules/rc/node_modules/ini": {
       "version": "1.3.8",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8095,6 +8091,38 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-check": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
+      "integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0"
+      }
+    },
+    "node_modules/update-check/node_modules/registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/update-check/node_modules/registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/update-notifier": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "inquirer": "^9.2.19",
     "node-fetch": "^2.7.0",
     "open": "^10.1.0",
+    "update-check": "^1.5.4",
     "uuid": "^9.0.1",
     "vitest": "^2.1.4"
   }

--- a/src/commands/general/init.ts
+++ b/src/commands/general/init.ts
@@ -41,6 +41,8 @@ export async function initAction(options: InitActionOptions, simulatorService: I
   simulatorService.setSimulatorLocation(options.location);
   simulatorService.setComposeOptions(options.headless);
 
+  await simulatorService.checkCliVersion();
+
   // Check if requirements are installed
   try {
     const requirementsInstalled = await simulatorService.checkInstallRequirements();

--- a/src/commands/general/start.ts
+++ b/src/commands/general/start.ts
@@ -16,6 +16,7 @@ export async function startAction(options: StartActionOptions, simulatorService:
   simulatorService.setComposeOptions(headless);
   simulatorService.setSimulatorLocation(location);
 
+  await simulatorService.checkCliVersion();
 
   const restartValidatorsHintText = resetValidators
     ? `creating new ${numValidators} random validators`

--- a/src/lib/interfaces/ISimulatorService.ts
+++ b/src/lib/interfaces/ISimulatorService.ts
@@ -20,6 +20,7 @@ export interface ISimulatorService {
   openFrontend(): Promise<boolean>;
   resetDockerContainers(): Promise<boolean>;
   resetDockerImages(): Promise<boolean>;
+  checkCliVersion(): Promise<void>;
 }
 
 export type DownloadSimulatorResultType = {

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -3,6 +3,8 @@ import * as fs from "fs";
 import * as dotenv from "dotenv";
 import * as path from "path";
 import * as semver from "semver";
+import updateCheck from "update-check";
+import pkg from '../../../package.json'
 
 import {rpcClient} from "../clients/jsonRpcClient";
 import {
@@ -91,6 +93,13 @@ export class SimulatorService implements ISimulatorService {
 
     // Write the new .env file
     fs.writeFileSync(envFilePath, updatedConfig);
+  }
+
+  public async checkCliVersion(): Promise<void> {
+    const update = await updateCheck(pkg);
+    if (update && update.latest !== pkg.version) {
+      console.warn(`\nA new version (${update.latest}) is available! You're using version ${pkg.version}.\nRun npm install -g genlayer to update\n`);
+    }
   }
 
   public async checkInstallRequirements(): Promise<Record<string, boolean>> {

--- a/tests/actions/start.test.ts
+++ b/tests/actions/start.test.ts
@@ -31,6 +31,7 @@ describe("startAction - Additional Tests", () => {
       openFrontend: vi.fn().mockResolvedValue(undefined),
       setSimulatorLocation: vi.fn().mockResolvedValue(undefined),
       setComposeOptions: vi.fn(),
+      checkCliVersion: vi.fn(),
       getAiProvidersOptions: vi.fn(() => [
         { name: "Provider A", value: "providerA" },
         { name: "Provider B", value: "providerB" },

--- a/tests/services/simulator.test.ts
+++ b/tests/services/simulator.test.ts
@@ -21,7 +21,15 @@ import { rpcClient } from "../../src/lib/clients/jsonRpcClient";
 import * as semver from "semver";
 import Docker from "dockerode";
 import {VersionRequiredError} from "../../src/lib/errors/versionRequired";
+import updateCheck from "update-check";
 
+vi.mock("../../package.json", () => ({
+  default: { version: "1.0.0", name: "genlayer" },
+}));
+
+vi.mock("update-check", () => ({
+  default: vi.fn(),
+}));
 vi.mock("dockerode");
 vi.mock("fs");
 vi.mock("path");
@@ -403,5 +411,45 @@ describe("SimulatorService - Docker Tests", () => {
       .mockRejectedValue(undefined);
     mockPing.mockRejectedValueOnce("Unexpected docker error");
     await expect(simulatorService.checkInstallRequirements()).rejects.toThrow("Unexpected docker error");
+  });
+
+  test("should warn the user when an update is available", async () => {
+    const update = { latest: "1.1.0" };
+    (updateCheck as any).mockResolvedValue(update);
+
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await simulatorService.checkCliVersion();
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      `\nA new version (${update.latest}) is available! You're using version 1.0.0.\nRun npm install -g genlayer to update\n`
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  test("should not warn the user when the CLI is up-to-date", async () => {
+    const update = { latest: "1.0.0" };
+    (updateCheck as any).mockResolvedValue(update);
+
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await simulatorService.checkCliVersion();
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  test("should handle update-check returning undefined", async () => {
+    (updateCheck as any).mockResolvedValue(undefined);
+
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await simulatorService.checkCliVersion();
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
This PR introduces a non-intrusive approach to notify users when a new version of the CLI is available. Instead of prompting users interactively, the update information is displayed as a message before command execution, ensuring that it does not interrupt the user's workflow.

### Why Non-Intrusive?

I chose the non-intrusive approach to:

- Preserve Workflow: Avoid disrupting users by prompting them during command execution.
- Follow Best Practices: Align with the approach used by widely adopted CLI tools like npm, git, yarn, and Docker, which display update notifications.
- User Control: Allow users to decide when to update, rather than forcing an immediate decision.