### PR TITLE
feat: keygen create command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "commander": "^12.0.0",
         "dockerode": "^4.0.2",
         "dotenv": "^16.4.5",
+        "ethers": "^6.13.4",
         "inquirer": "^9.2.19",
         "node-fetch": "^2.7.0",
         "open": "^10.1.0",
@@ -51,6 +52,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -540,6 +547,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1492,6 +1523,12 @@
     "node_modules/add-stream": {
       "version": "1.0.0",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
       "license": "MIT"
     },
     "node_modules/agent-base": {
@@ -3583,6 +3620,64 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.13.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
+      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/execa": {
@@ -7903,7 +7998,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
     },
     "node_modules/tweetnacl": {
@@ -8056,7 +8153,6 @@
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "commander": "^12.0.0",
     "dockerode": "^4.0.2",
     "dotenv": "^16.4.5",
+    "ethers": "^6.13.4",
     "inquirer": "^9.2.19",
     "node-fetch": "^2.7.0",
     "open": "^10.1.0",

--- a/src/commands/general/index.ts
+++ b/src/commands/general/index.ts
@@ -1,9 +1,8 @@
-import {Command} from "commander";
+import { Command } from "commander";
 
 import simulatorService from "../../lib/services/simulator";
-
-import {initAction, InitActionOptions} from "./init";
-import {startAction, StartActionOptions} from "./start";
+import { initAction, InitActionOptions } from "./init";
+import { startAction, StartActionOptions } from "./start";
 
 export function initializeGeneralCommands(program: Command) {
   program

--- a/src/commands/keygen/create.ts
+++ b/src/commands/keygen/create.ts
@@ -1,9 +1,10 @@
-import { writeFileSync } from "fs";
+import { writeFileSync, existsSync } from "fs";
 import { ethers } from "ethers";
 import { ConfigFileManager } from "../../lib/config/ConfigFileManager";
 
 export interface CreateKeypairOptions {
   output: string;
+  overwrite: boolean;
 }
 
 export class KeypairCreator {
@@ -15,13 +16,22 @@ export class KeypairCreator {
 
   createKeypairAction(options: CreateKeypairOptions) {
     try {
+
+      const outputPath = this.filePathManager.getFilePath(options.output);
+
+      if(existsSync(outputPath) && !options.overwrite) {
+        console.warn(
+          `The file at ${outputPath} already exists. Use the '--overwrite' option to replace it.`
+        );
+        return;
+      }
+
       const wallet = ethers.Wallet.createRandom();
       const keypairData = {
         address: wallet.address,
         privateKey: wallet.privateKey,
       };
 
-      const outputPath = this.filePathManager.getFilePath(options.output);
       writeFileSync(outputPath, JSON.stringify(keypairData, null, 2));
 
       this.filePathManager.writeConfig('keyPairPath', outputPath);

--- a/src/commands/keygen/create.ts
+++ b/src/commands/keygen/create.ts
@@ -1,0 +1,34 @@
+import { writeFileSync } from "fs";
+import { ethers } from "ethers";
+import { ConfigFileManager } from "../../lib/config/ConfigFileManager";
+
+export interface CreateKeypairOptions {
+  output: string;
+}
+
+export class KeypairCreator {
+  private filePathManager: ConfigFileManager;
+
+  constructor() {
+    this.filePathManager = new ConfigFileManager();
+  }
+
+  createKeypairAction(options: CreateKeypairOptions) {
+    try {
+      const wallet = ethers.Wallet.createRandom();
+      const keypairData = {
+        address: wallet.address,
+        privateKey: wallet.privateKey,
+      };
+
+      const outputPath = this.filePathManager.getFilePath(options.output);
+      writeFileSync(outputPath, JSON.stringify(keypairData, null, 2));
+
+      this.filePathManager.writeConfig('keyPairPath', outputPath);
+      console.log(`Keypair successfully created and saved to: ${outputPath}`);
+    } catch (error) {
+      console.error("Failed to generate keypair:", error);
+      process.exit(1);
+    }
+  }
+}

--- a/src/commands/keygen/index.ts
+++ b/src/commands/keygen/index.ts
@@ -1,0 +1,20 @@
+import { Command } from "commander";
+import { KeypairCreator } from "./create";
+
+export function initializeKeygenCommands(program: Command) {
+
+  const keygenCommand = program
+    .command("keygen")
+    .description("Manage keypair generation");
+
+  keygenCommand
+    .command("create")
+    .description("Generates a new keypair and saves it to a file")
+    .option("--output <path>", "Path to save the keypair", "./keypair.json")
+    .action((options: { output: string }) => {
+      const keypairCreator = new KeypairCreator();
+      keypairCreator.createKeypairAction({ output: options.output });
+    });
+
+  return program;
+}

--- a/src/commands/keygen/index.ts
+++ b/src/commands/keygen/index.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { KeypairCreator } from "./create";
+import { CreateKeypairOptions, KeypairCreator } from "./create";
 
 export function initializeKeygenCommands(program: Command) {
 
@@ -11,9 +11,10 @@ export function initializeKeygenCommands(program: Command) {
     .command("create")
     .description("Generates a new keypair and saves it to a file")
     .option("--output <path>", "Path to save the keypair", "./keypair.json")
-    .action((options: { output: string }) => {
+    .option("--overwrite", "Overwrite the existing file if it already exists", false)
+    .action((options: CreateKeypairOptions) => {
       const keypairCreator = new KeypairCreator();
-      keypairCreator.createKeypairAction({ output: options.output });
+      keypairCreator.createKeypairAction(options);
     });
 
   return program;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,13 @@
 import {program} from "commander";
 import {version} from "../package.json";
 import {CLI_DESCRIPTION} from "../src/lib/config/text";
-import {initializeGeneralCommands} from "../src/commands/general";
+import { initializeGeneralCommands } from "../src/commands/general";
+import { initializeKeygenCommands } from "../src/commands/keygen";
 
 export function initializeCLI() {
   program.version(version).description(CLI_DESCRIPTION);
   initializeGeneralCommands(program);
+  initializeKeygenCommands(program);
   program.parse(process.argv);
 }
 

--- a/src/lib/config/ConfigFileManager.ts
+++ b/src/lib/config/ConfigFileManager.ts
@@ -1,0 +1,51 @@
+import path from "path";
+import os from "os";
+import fs from "fs";
+
+export class ConfigFileManager {
+  private folderPath: string;
+  private configFilePath: string;
+
+  constructor(baseFolder: string = ".genlayer/", configFileName: string = "genlayer-config.json") {
+    this.folderPath = path.resolve(os.homedir(), baseFolder);
+    this.configFilePath = path.resolve(this.folderPath, configFileName);
+    this.ensureFolderExists();
+    this.ensureConfigFileExists();
+  }
+
+  private ensureFolderExists(): void {
+    if (!fs.existsSync(this.folderPath)) {
+      fs.mkdirSync(this.folderPath, { recursive: true });
+    }
+  }
+
+  private ensureConfigFileExists(): void {
+    if (!fs.existsSync(this.configFilePath)) {
+      fs.writeFileSync(this.configFilePath, JSON.stringify({}, null, 2));
+    }
+  }
+
+  getFolderPath(): string {
+    return this.folderPath;
+  }
+
+  getFilePath(fileName: string): string {
+    return path.resolve(this.folderPath, fileName);
+  }
+
+  getConfig(): Record<string, any> {
+    const configContent = fs.readFileSync(this.configFilePath, "utf-8");
+    return JSON.parse(configContent);
+  }
+
+  getConfigByKey(key: string): any {
+    const config = this.getConfig();
+    return config[key] !== undefined ? config[key] : null;
+  }
+
+  writeConfig(key: string, value: any): void {
+    const config = this.getConfig();
+    config[key] = value;
+    fs.writeFileSync(this.configFilePath, JSON.stringify(config, null, 2));
+  }
+}

--- a/tests/actions/create.test.ts
+++ b/tests/actions/create.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, vi, beforeEach, afterEach, expect } from "vitest";
+import { KeypairCreator } from "../../src/commands/keygen/create";
+import { writeFileSync } from "fs";
+import { ethers } from "ethers";
+
+vi.mock("fs");
+
+vi.mock("ethers", () => ({
+  ethers: {
+    Wallet: {
+      createRandom: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../../src/lib/config/ConfigFileManager", () => ({
+  ConfigFileManager: vi.fn().mockImplementation(() => ({
+    getFilePath: vi.fn((fileName) => `/mocked/path/${fileName}`),
+    writeConfig: vi.fn(),
+  })),
+}));
+
+describe("KeypairCreator", () => {
+  let keypairCreator: KeypairCreator;
+
+  const mockWallet: any = {
+    address: "0xMockedAddress",
+    privateKey: "0xMockedPrivateKey",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    keypairCreator = new KeypairCreator();
+    vi.mocked(ethers.Wallet.createRandom).mockReturnValue(mockWallet);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("successfully creates and saves a keypair", () => {
+    const consoleLogSpy = vi.spyOn(console, "log");
+    const options = { output: "keypair.json" };
+
+    keypairCreator.createKeypairAction(options);
+
+    expect(ethers.Wallet.createRandom).toHaveBeenCalledTimes(1);
+
+    expect(keypairCreator["filePathManager"].getFilePath).toHaveBeenCalledWith("keypair.json");
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      "/mocked/path/keypair.json",
+      JSON.stringify(
+        {
+          address: mockWallet.address,
+          privateKey: mockWallet.privateKey,
+        },
+        null,
+        2
+      )
+    );
+
+    expect(keypairCreator["filePathManager"].writeConfig).toHaveBeenCalledWith(
+      "keyPairPath",
+      "/mocked/path/keypair.json"
+    );
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "Keypair successfully created and saved to: /mocked/path/keypair.json"
+    );
+  });
+
+
+  test("handles errors during keypair creation", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error");
+    const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    vi.mocked(writeFileSync).mockImplementation(() => {
+      throw new Error("Mocked write error");
+    });
+
+    expect(() => {
+      keypairCreator.createKeypairAction({ output: "keypair.json" });
+    }).toThrowError("process.exit");
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to generate keypair:", expect.any(Error));
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/commands/keygen.test.ts
+++ b/tests/commands/keygen.test.ts
@@ -1,0 +1,54 @@
+import { Command } from "commander";
+import { vi, describe, beforeEach, afterEach, test, expect } from "vitest";
+import { initializeKeygenCommands } from "../../src/commands/keygen";
+import { KeypairCreator } from "../../src/commands/keygen/create";
+
+vi.mock("../../src/commands/keygen/create")
+
+describe("keygen create command", () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = new Command();
+    initializeKeygenCommands(program);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("keypairCreator.createKeypairAction is called with default options", async () => {
+    program.parse(["node", "test", "keygen", "create"]);
+    expect(KeypairCreator).toHaveBeenCalledTimes(1);
+    expect(KeypairCreator.prototype.createKeypairAction).toHaveBeenCalledWith({ output: "./keypair.json" });
+  });
+
+  test("keypairCreator.createKeypairAction is called with custom options", async () => {
+    program.parse(["node", "test", "keygen", "create", "--output", "./custom.json"]);
+    expect(KeypairCreator).toHaveBeenCalledTimes(1);
+    expect(KeypairCreator.prototype.createKeypairAction).toHaveBeenCalledWith({ output: "./custom.json" });
+  });
+
+  test("KeypairCreator is instantiated when the command is executed", async () => {
+    program.parse(["node", "test", "keygen", "create"]);
+    expect(KeypairCreator).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws error for unrecognized options", async () => {
+    const keygenCommand = program.commands.find(cmd => cmd.name() === "keygen");
+    const createCommand = keygenCommand?.commands.find(cmd => cmd.name() === "create");
+
+    createCommand?.exitOverride();
+    expect(() => program.parse(["node", "test", "keygen", "create", "--unknown"])).toThrowError(
+      "error: unknown option '--unknown'"
+    );
+  });
+
+  test("keypairCreator.createKeypairAction is called with default options", async () => {
+    program.parse(["node", "test", "keygen", "create"]);
+    vi.mocked(KeypairCreator.prototype.createKeypairAction).mockReturnValue()
+    expect(() => program.parse(["node", "test", "keygen", "create"])).not.toThrow();
+  });
+});
+

--- a/tests/commands/keygen.test.ts
+++ b/tests/commands/keygen.test.ts
@@ -3,7 +3,7 @@ import { vi, describe, beforeEach, afterEach, test, expect } from "vitest";
 import { initializeKeygenCommands } from "../../src/commands/keygen";
 import { KeypairCreator } from "../../src/commands/keygen/create";
 
-vi.mock("../../src/commands/keygen/create")
+vi.mock("../../src/commands/keygen/create");
 
 describe("keygen create command", () => {
   let program: Command;
@@ -21,13 +21,37 @@ describe("keygen create command", () => {
   test("keypairCreator.createKeypairAction is called with default options", async () => {
     program.parse(["node", "test", "keygen", "create"]);
     expect(KeypairCreator).toHaveBeenCalledTimes(1);
-    expect(KeypairCreator.prototype.createKeypairAction).toHaveBeenCalledWith({ output: "./keypair.json" });
+    expect(KeypairCreator.prototype.createKeypairAction).toHaveBeenCalledWith({
+      output: "./keypair.json",
+      overwrite: false,
+    });
   });
 
-  test("keypairCreator.createKeypairAction is called with custom options", async () => {
+  test("keypairCreator.createKeypairAction is called with custom output option", async () => {
     program.parse(["node", "test", "keygen", "create", "--output", "./custom.json"]);
     expect(KeypairCreator).toHaveBeenCalledTimes(1);
-    expect(KeypairCreator.prototype.createKeypairAction).toHaveBeenCalledWith({ output: "./custom.json" });
+    expect(KeypairCreator.prototype.createKeypairAction).toHaveBeenCalledWith({
+      output: "./custom.json",
+      overwrite: false,
+    });
+  });
+
+  test("keypairCreator.createKeypairAction is called with overwrite enabled", async () => {
+    program.parse(["node", "test", "keygen", "create", "--overwrite"]);
+    expect(KeypairCreator).toHaveBeenCalledTimes(1);
+    expect(KeypairCreator.prototype.createKeypairAction).toHaveBeenCalledWith({
+      output: "./keypair.json",
+      overwrite: true,
+    });
+  });
+
+  test("keypairCreator.createKeypairAction is called with custom output and overwrite enabled", async () => {
+    program.parse(["node", "test", "keygen", "create", "--output", "./custom.json", "--overwrite"]);
+    expect(KeypairCreator).toHaveBeenCalledTimes(1);
+    expect(KeypairCreator.prototype.createKeypairAction).toHaveBeenCalledWith({
+      output: "./custom.json",
+      overwrite: true,
+    });
   });
 
   test("KeypairCreator is instantiated when the command is executed", async () => {
@@ -36,8 +60,8 @@ describe("keygen create command", () => {
   });
 
   test("throws error for unrecognized options", async () => {
-    const keygenCommand = program.commands.find(cmd => cmd.name() === "keygen");
-    const createCommand = keygenCommand?.commands.find(cmd => cmd.name() === "create");
+    const keygenCommand = program.commands.find((cmd) => cmd.name() === "keygen");
+    const createCommand = keygenCommand?.commands.find((cmd) => cmd.name() === "create");
 
     createCommand?.exitOverride();
     expect(() => program.parse(["node", "test", "keygen", "create", "--unknown"])).toThrowError(
@@ -45,10 +69,9 @@ describe("keygen create command", () => {
     );
   });
 
-  test("keypairCreator.createKeypairAction is called with default options", async () => {
+  test("keypairCreator.createKeypairAction is called without throwing errors for default options", async () => {
     program.parse(["node", "test", "keygen", "create"]);
-    vi.mocked(KeypairCreator.prototype.createKeypairAction).mockReturnValue()
+    vi.mocked(KeypairCreator.prototype.createKeypairAction).mockReturnValue();
     expect(() => program.parse(["node", "test", "keygen", "create"])).not.toThrow();
   });
 });
-

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -13,6 +13,10 @@ vi.mock("../src/commands/general", () => ({
   initializeGeneralCommands: vi.fn(),
 }));
 
+vi.mock("../src/commands/keygen", () => ({
+  initializeKeygenCommands: vi.fn(),
+}));
+
 
 describe("CLI", () => {
   it("should initialize CLI", () => {

--- a/tests/libs/configFileManager.test.ts
+++ b/tests/libs/configFileManager.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, vi, beforeEach, afterEach, expect } from "vitest";
+import { ConfigFileManager } from "../../src/lib/config/ConfigFileManager";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+vi.mock("fs");
+
+vi.mock("os")
+
+describe("ConfigFileManager", () => {
+  const mockFolderPath = "/mocked/home/.genlayer";
+  const mockConfigFilePath = `${mockFolderPath}/genlayer-config.json`;
+
+  let configFileManager: ConfigFileManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(os.homedir).mockReturnValue("/mocked/home");
+    configFileManager = new ConfigFileManager();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("ensures folder and config file are created if they don't exist", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    new ConfigFileManager();
+
+    expect(fs.existsSync).toHaveBeenCalledWith(mockFolderPath);
+    expect(fs.mkdirSync).toHaveBeenCalledWith(mockFolderPath, { recursive: true });
+
+    expect(fs.existsSync).toHaveBeenCalledWith(mockConfigFilePath);
+    expect(fs.writeFileSync).toHaveBeenCalledWith(mockConfigFilePath, JSON.stringify({}, null, 2));
+  });
+
+  test("does not recreate folder or config file if they exist", () => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    new ConfigFileManager();
+
+    expect(fs.mkdirSync).not.toHaveBeenCalled();
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  test("getFolderPath returns the correct folder path", () => {
+    expect(configFileManager.getFolderPath()).toBe(mockFolderPath);
+  });
+
+  test("getFilePath returns the correct file path for a given file name", () => {
+    const fileName = "example.json";
+    const expectedFilePath = path.resolve(mockFolderPath, fileName);
+
+    expect(configFileManager.getFilePath(fileName)).toBe(expectedFilePath);
+  });
+
+  test("getConfig returns the parsed content of the config file", () => {
+    const mockConfig = { key: "value" };
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockConfig));
+
+    const config = configFileManager.getConfig();
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(mockConfigFilePath, "utf-8");
+    expect(config).toEqual(mockConfig);
+  });
+
+  test("getConfigByKey returns the value for a given key", () => {
+    const mockConfig = { key: "value" };
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockConfig));
+
+    const value = configFileManager.getConfigByKey("key");
+
+    expect(value).toBe("value");
+  });
+
+  test("getConfigByKey returns null for a non-existing key", () => {
+    const mockConfig = { key: "value" };
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockConfig));
+
+    const value = configFileManager.getConfigByKey("nonExistingKey");
+
+    expect(value).toBeNull();
+  });
+
+  test("writeConfig updates the config file with a new key-value pair", () => {
+    const mockConfig = { existingKey: "existingValue" };
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockConfig));
+
+    configFileManager.writeConfig("newKey", "newValue");
+
+    const expectedConfig = { existingKey: "existingValue", newKey: "newValue" };
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      mockConfigFilePath,
+      JSON.stringify(expectedConfig, null, 2)
+    );
+  });
+
+  test("writeConfig overwrites an existing key in the config file", () => {
+    const mockConfig = { existingKey: "existingValue" };
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockConfig));
+
+    configFileManager.writeConfig("existingKey", "updatedValue");
+
+    const expectedConfig = { existingKey: "updatedValue" };
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      mockConfigFilePath,
+      JSON.stringify(expectedConfig, null, 2)
+    );
+  });
+});


### PR DESCRIPTION
## New command

keygen create

Generate a new cryptographic keypair.
genlayer keygen create [options]


 Options:
 --output <file>: Specify the file to save the generated keypair (default: keypair.json).
  --overwrite: Overwrite the existing file if it already exists (default: false).
