### PR TITLE
fix: removing volumes to stop error when running node without nvm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,10 +142,3 @@ services:
         condition: service_healthy
       webrequest:
         condition: service_healthy
-
-  hardhat:
-    image: yeagerai/simulator-hardhat
-    ports:
-      - "${HARDHAT_PORT:-8545}:8545"
-    environment:
-      - HARDHAT_NETWORK=hardhat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       - "${FRONTEND_PORT:-8080}:8080"
     environment:
       - VITE_*
-    volumes:
-      - ./.env:/app/.env
+    env_file:
+      - ./.env
     depends_on:
       jsonrpc:
         condition: service_healthy
@@ -36,8 +36,8 @@ services:
     ports:
       - "${RPCPORT:-5000}:${RPCPORT:-5000}"
       - "${RPCDEBUGPORT:-5001}:${RPCDEBUGPORT:-5001}"
-    volumes:
-      - ./.env:/app/.env
+    env_file:
+      - ./.env
     healthcheck:
       test: [ "CMD", "python", "backend/healthcheck.py", "--port", "${RPCPORT}" ]
       interval: 30s
@@ -75,8 +75,8 @@ services:
     expose:
       - "${WEBREQUESTPORT:-5002}:${WEBREQUESTPORT:-5002}"
       - "${WEBREQUESTSELENIUMPORT:-4444}:${WEBREQUESTSELENIUMPORT:-4444}"
-    volumes:
-      - ./.env:/app/webrequest/.env
+    env_file:
+      - ./.env
     depends_on:
       ollama:
         condition: service_started
@@ -142,3 +142,10 @@ services:
         condition: service_healthy
       webrequest:
         condition: service_healthy
+
+  hardhat:
+    image: yeagerai/simulator-hardhat
+    ports:
+      - "${HARDHAT_PORT:-8545}:8545"
+    environment:
+      - HARDHAT_NETWORK=hardhat

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -50,9 +50,6 @@ export class SimulatorService implements ISimulatorService {
   public addConfigToEnvFile(newConfig: Record<string, string>): void {
     const envFilePath = path.join(this.location, ".env");
 
-    // Create a backup of the original .env file
-    fs.writeFileSync(`${envFilePath}.bak`, fs.readFileSync(envFilePath));
-
     // Transform the config string to object
     const envConfig = dotenv.parse(fs.readFileSync(envFilePath, "utf8"));
     Object.keys(newConfig).forEach(key => {

--- a/tests/services/simulator.test.ts
+++ b/tests/services/simulator.test.ts
@@ -173,7 +173,6 @@ describe("SimulatorService - Basic Tests", () => {
 
     simulatorService.addConfigToEnvFile(newConfig);
 
-    expect(writeFileSyncMock).toHaveBeenCalledWith(`${envFilePath}.bak`, "");
     const expectedUpdatedContent = `NEW_KEY=newValue`;
     expect(writeFileSyncMock).toHaveBeenCalledWith(envFilePath, expectedUpdatedContent);
   });


### PR DESCRIPTION
#### **Summary**
This PR introduces the following changes to improve usability and resolve permission-related issues when running GenLayer:

1. **Replaced `.env` Volumes with `env_file`:**
   - Removed the use of `.env` volumes in Docker Compose.
   - Implemented `env_file` for loading environment variables into containers.
   - This resolves errors that occurred when GenLayer was installed globally in directories that Docker could not mount (e.g., `/usr/local/lib`).

2. **Removed `.env.bak` Creation:**
   - Eliminated the automatic creation of `.env.bak` files.
   - This allows users to run GenLayer without requiring root privileges

#### **Testing**
- Verified the new `env_file` configuration on **beta version 0.8.1-beta.0** to ensure it functions as expected.
- Confirmed that containers correctly load environment variables via `env_file`
