### PR TITLE
feat: getting default ollama model from config file

### DIFF
--- a/src/commands/general/init.ts
+++ b/src/commands/general/init.ts
@@ -2,6 +2,7 @@ import inquirer from "inquirer";
 import {ISimulatorService} from "../../lib/interfaces/ISimulatorService";
 import {AI_PROVIDERS_CONFIG, AiProviders} from "../../lib/config/simulator";
 import { OllamaAction } from "../update/ollama";
+import { ConfigFileManager } from "../../lib/config/ConfigFileManager";
 
 export interface InitActionOptions {
   numValidators: number;
@@ -179,9 +180,16 @@ export async function initAction(options: InitActionOptions, simulatorService: I
 
   // Ollama doesn't need changes in configuration, we just run it
   if (selectedLlmProviders.includes("ollama")) {
-    console.log("Pulling llama3 from Ollama...");
+
     const ollamaAction = new OllamaAction();
-    await ollamaAction.updateModel("llama3");
+    const configManager = new ConfigFileManager();
+    const config = configManager.getConfig()
+
+    let ollamaModel = config.defaultOllamaModel || 'llama3';
+
+    console.log(`Pulling ${ollamaModel} from Ollama...`);
+
+    await ollamaAction.updateModel(ollamaModel);
   }
 
   // Initializing validators


### PR DESCRIPTION
## Changes Introduced

### 1. Configurable Default Ollama Model
- The `initAction` now respects the `defaultOllamaModel` configuration set in the `GenLayer` config file.
- Users can configure the default Ollama model using the command:
  ```bash
  genlayer config set defaultOllamaModel=gemma
  ```
- If `defaultOllamaModel` is not set, the default remains `"llama3"`.

### 2. Code Enhancements
- Updated `initAction` to dynamically pull the model specified in `defaultOllamaModel`.
- Improved logging to display the specific model being pulled.
- Added a fallback mechanism to use `"llama3"` when `defaultOllamaModel` is not configured.

### 3. Test Updates
- **New Test Case**: Ensures that the correct model is pulled based on the configured `defaultOllamaModel`.
- **Default Behavior Test**: Verifies that the model defaults to `"llama3"` when no configuration is provided.

## Usage Example
1. Set a custom default Ollama model:
   ```bash
   genlayer config set defaultOllamaModel=gemma
   ```
2. Run the `initAction` command:
   ```
   Pulling gemma from Ollama...
   ```

## Impact

This update enhances the `initAction` command, enabling a more user-configurable experience for Ollama provider integration.