### PR TITLE
fix: updating studio version and docker compose breaking change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     env_file:
       - ./.env
     healthcheck:
-      test: [ "CMD", "python", "backend/healthcheck.py", "--port", "${RPCPORT}" ]
+      test: [ "CMD", "python3", "backend/healthcheck.py", "--port", "${RPCPORT}" ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -1,4 +1,4 @@
-export const localnetCompatibleVersion = "v0.29.0";
+export const localnetCompatibleVersion = "v0.34.3";
 export const DEFAULT_JSON_RPC_URL = "http://localhost:4000/api";
 export const CONTAINERS_NAME_PREFIX = "/genlayer-";
 export const IMAGES_NAME_PREFIX = "yeagerai";


### PR DESCRIPTION
- Updating studio version (it has a breaking change on docker compose)
- Now CLI users could use Studio version containing a metamask feature