### PR TITLE
feat: Add `stop` Command and Improve Docker Container Management

### DIFF
--- a/src/commands/general/index.ts
+++ b/src/commands/general/index.ts
@@ -4,6 +4,7 @@ import simulatorService from "../../lib/services/simulator";
 import { initAction, InitActionOptions } from "./init";
 import { startAction, StartActionOptions } from "./start";
 import {localnetCompatibleVersion} from "../../lib/config/simulator";
+import {StopAction} from "./stop";
 
 export function initializeGeneralCommands(program: Command) {
   program
@@ -23,6 +24,14 @@ export function initializeGeneralCommands(program: Command) {
     .option("--headless", "Headless mode", false)
     .option("--reset-db", "Reset Database", false)
     .action((options: StartActionOptions) => startAction(options, simulatorService));
+
+  program
+    .command("stop")
+    .description("Stop all running simulator services.")
+    .action(async () => {
+      const stopAction = new StopAction();
+      await stopAction.stop();
+    });
 
   return program;
 }

--- a/src/commands/general/index.ts
+++ b/src/commands/general/index.ts
@@ -27,7 +27,7 @@ export function initializeGeneralCommands(program: Command) {
 
   program
     .command("stop")
-    .description("Stop all running simulator services.")
+    .description("Stop all running localnet services.")
     .action(async () => {
       const stopAction = new StopAction();
       await stopAction.stop();

--- a/src/commands/general/stop.ts
+++ b/src/commands/general/stop.ts
@@ -7,7 +7,7 @@ export class StopAction extends BaseAction {
 
   constructor() {
     super();
-    this.simulatorService = new SimulatorService(); // Correctly instantiate the service
+    this.simulatorService = new SimulatorService();
   }
 
   public async stop(): Promise<void> {
@@ -15,7 +15,9 @@ export class StopAction extends BaseAction {
       await this.confirmPrompt(
         "Are you sure you want to stop all running GenLayer containers? This will halt all active processes."
       );
+      console.log(`Stopping Docker containers...`);
       await this.simulatorService.stopDockerContainers();
+      console.log(`All running GenLayer containers have been successfully stopped.`);
     }catch (error) {
       console.error("An error occurred while stopping the containers:", error)
     }

--- a/src/commands/general/stop.ts
+++ b/src/commands/general/stop.ts
@@ -1,0 +1,23 @@
+import { BaseAction } from "../../lib/actions/BaseAction";
+import { SimulatorService } from "../../lib/services/simulator";
+import { ISimulatorService } from "../../lib/interfaces/ISimulatorService";
+
+export class StopAction extends BaseAction {
+  private simulatorService: ISimulatorService;
+
+  constructor() {
+    super();
+    this.simulatorService = new SimulatorService(); // Correctly instantiate the service
+  }
+
+  public async stop(): Promise<void> {
+    try{
+      await this.confirmPrompt(
+        "Are you sure you want to stop all running GenLayer containers? This will halt all active processes."
+      );
+      await this.simulatorService.stopDockerContainers();
+    }catch (error) {
+      console.error("An error occurred while stopping the containers:", error)
+    }
+  }
+}

--- a/src/lib/interfaces/ISimulatorService.ts
+++ b/src/lib/interfaces/ISimulatorService.ts
@@ -12,8 +12,9 @@ export interface ISimulatorService {
   getAiProvidersOptions(withHint: boolean): Array<{name: string; value: string}>;
   getFrontendUrl(): string;
   openFrontend(): Promise<boolean>;
-  resetDockerContainers(): Promise<boolean>;
-  resetDockerImages(): Promise<boolean>;
+  stopDockerContainers(): Promise<void>;
+  resetDockerContainers(): Promise<void>;
+  resetDockerImages(): Promise<void>;
   checkCliVersion(): Promise<void>;
   cleanDatabase(): Promise<boolean>;
   addConfigToEnvFile(newConfig: Record<string, string>): void;

--- a/tests/actions/stop.test.ts
+++ b/tests/actions/stop.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, vi, beforeEach, afterEach, expect } from "vitest";
+import { StopAction } from "../../src/commands/general/stop";
+import { SimulatorService } from "../../src/lib/services/simulator";
+import { ISimulatorService } from "../../src/lib/interfaces/ISimulatorService";
+import inquirer from "inquirer";
+
+vi.mock("../../src/lib/services/simulator");
+vi.mock("inquirer");
+
+describe("StopAction", () => {
+  let stopAction: StopAction;
+  let mockSimulatorService: ISimulatorService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSimulatorService = {
+      stopDockerContainers: vi.fn(),
+    } as unknown as ISimulatorService;
+
+    SimulatorService.prototype.stopDockerContainers = mockSimulatorService.stopDockerContainers;
+
+    stopAction = new StopAction();
+    (stopAction as any).simulatorService = mockSimulatorService;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("should stop containers if user confirms", async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({ confirmAction: true });
+
+    await stopAction.stop();
+
+    expect(inquirer.prompt).toHaveBeenCalledWith([
+      {
+        type: "confirm",
+        name: "confirmAction",
+        message: "Are you sure you want to stop all running GenLayer containers? This will halt all active processes.",
+        default: true,
+      },
+    ]);
+    expect(mockSimulatorService.stopDockerContainers).toHaveBeenCalled();
+  });
+
+  test("should abort if user cancels", async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({ confirmAction: false });
+
+    console.log = vi.fn();
+
+    await stopAction.stop();
+
+    expect(inquirer.prompt).toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith("Operation aborted!");
+    expect(mockSimulatorService.stopDockerContainers).not.toHaveBeenCalled();
+  });
+});

--- a/tests/commands/stop.test.ts
+++ b/tests/commands/stop.test.ts
@@ -1,0 +1,27 @@
+import { Command } from "commander";
+import { vi, describe, beforeEach, afterEach, test, expect } from "vitest";
+import { initializeGeneralCommands } from "../../src/commands/general";
+import { StopAction } from "../../src/commands/general/stop";
+
+vi.mock("../../src/commands/general/stop");
+
+describe("stop command", () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = new Command();
+    initializeGeneralCommands(program);
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("doesn't require arguments or options", async () => {
+    expect(() => program.parse(["node", "test", "stop"])).not.toThrow();
+    expect(StopAction).toHaveBeenCalledTimes(1);
+    expect(StopAction.prototype.stop).toHaveBeenCalledWith();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    testTimeout: 10000,
     coverage: {
       exclude: [...configDefaults.exclude, '*.js', 'tests/**/*.ts', 'src/types', 'scripts'],
     }


### PR DESCRIPTION
## Summary
This PR introduces the `stop` command to halt all running GenLayer simulator services. It also enhances the Docker container management logic by refactoring container stopping and removal functionalities.

## Key Changes
- **New `stop` Command**
  - Added `stop` command to `initializeGeneralCommands` in `src/commands/general/index.ts`.
  - Created `StopAction` class in `src/commands/general/stop.ts` to handle stopping the simulator.
  - Integrated a confirmation prompt before stopping containers.

- **Refactored Docker Container Management**
  - Introduced `stopAndRemoveContainers` method to avoid duplicated code in `SimulatorService`.
  - Updated `stopDockerContainers` and `resetDockerContainers` to use this new method.
  - Now excludes `"ollama"` containers from removal when resetting Docker containers.

- **Updates to `ISimulatorService`**
  - Declared `stopDockerContainers()` in `ISimulatorService`.

- **Removed Unused Boolean Returns**
  - Removed unused boolean return values from `resetDockerContainers` and `resetDockerImages` methods.

- **Test Coverage Improvements**
  - Added unit tests for `StopAction` in `tests/actions/stop.test.ts`.
  - Added command registration test in `tests/commands/stop.test.ts`.
  - Included tests for `stopDockerContainers` in `tests/services/simulator.test.ts`.
  - Increased test timeout globally (`testTimeout: 10000`) in `vitest.config.ts` to prevent flaky tests.
