### PR TITLE
feat: using profiles to set frontend and ollama containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     image: ollama/ollama:0.6.6
     ports:
       - 11434:11434
-    container_name: ollama
+    container_name: genlayer-ollama
     tty: true
     restart: always
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    profiles:
+      - frontend
 
 
   jsonrpc:
@@ -83,6 +85,7 @@ services:
     depends_on:
       ollama:
         condition: service_started
+        required: false
     restart: always
     security_opt:
       - "no-new-privileges=true"
@@ -106,6 +109,8 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    profiles:
+      - ollama
 
   postgres:
     image: postgres:17-alpine

--- a/src/commands/general/index.ts
+++ b/src/commands/general/index.ts
@@ -14,7 +14,7 @@ export function initializeGeneralCommands(program: Command) {
     .option("--headless", "Headless mode", false)
     .option("--reset-db", "Reset Database", false)
     .option("--localnet-version <localnetVersion>", "Select a specific localnet version", localnetCompatibleVersion)
-    .option("--disable-ollama", "Disable Ollama container", false)
+    .option("--ollama", "Enable Ollama container", false)
     .action(async (options: InitActionOptions) => {
       const initAction = new InitAction();
       await initAction.execute(options)
@@ -27,7 +27,7 @@ export function initializeGeneralCommands(program: Command) {
     .option("--numValidators <numValidators>", "Number of validators", "5")
     .option("--headless", "Headless mode", false)
     .option("--reset-db", "Reset Database", false)
-    .option("--disable-ollama", "Disable Ollama container", false)
+    .option("--ollama", "Enable Ollama container", false)
     .action(async (options: StartActionOptions) => {
       const startAction = new StartAction();
       await startAction.execute(options);

--- a/src/commands/general/index.ts
+++ b/src/commands/general/index.ts
@@ -14,6 +14,7 @@ export function initializeGeneralCommands(program: Command) {
     .option("--headless", "Headless mode", false)
     .option("--reset-db", "Reset Database", false)
     .option("--localnet-version <localnetVersion>", "Select a specific localnet version", localnetCompatibleVersion)
+    .option("--disable-ollama", "Disable Ollama container", false)
     .action(async (options: InitActionOptions) => {
       const initAction = new InitAction();
       await initAction.execute(options)
@@ -26,6 +27,7 @@ export function initializeGeneralCommands(program: Command) {
     .option("--numValidators <numValidators>", "Number of validators", "5")
     .option("--headless", "Headless mode", false)
     .option("--reset-db", "Reset Database", false)
+    .option("--disable-ollama", "Disable Ollama container", false)
     .action(async (options: StartActionOptions) => {
       const startAction = new StartAction();
       await startAction.execute(options);

--- a/src/commands/general/init.ts
+++ b/src/commands/general/init.ts
@@ -11,6 +11,7 @@ export interface InitActionOptions {
   headless: boolean;
   resetDb: boolean;
   localnetVersion: string;
+  disableOllama: boolean;
 }
 
 function getRequirementsErrorMessage({ docker }: Record<string, boolean>): string {
@@ -41,7 +42,7 @@ export class InitAction extends BaseAction {
 
   public async execute(options: InitActionOptions): Promise<void> {
     try {
-      this.simulatorService.setComposeOptions(options.headless);
+      this.simulatorService.setComposeOptions(options.headless, options.disableOllama);
       let localnetVersion = options.localnetVersion;
       if (localnetVersion !== "latest") {
         localnetVersion = this.simulatorService.normalizeLocalnetVersion(localnetVersion);
@@ -141,7 +142,7 @@ export class InitAction extends BaseAction {
 
       this.stopSpinner();
 
-      if (selectedLlmProviders.includes("ollama")) {
+      if (selectedLlmProviders.includes("ollama") && !options.disableOllama) {
         const ollamaAction = new OllamaAction();
         if (!defaultOllamaModel) {
           this.writeConfig("defaultOllamaModel", "llama3");

--- a/src/commands/general/init.ts
+++ b/src/commands/general/init.ts
@@ -11,7 +11,7 @@ export interface InitActionOptions {
   headless: boolean;
   resetDb: boolean;
   localnetVersion: string;
-  disableOllama: boolean;
+  ollama: boolean;
 }
 
 function getRequirementsErrorMessage({ docker }: Record<string, boolean>): string {
@@ -42,7 +42,7 @@ export class InitAction extends BaseAction {
 
   public async execute(options: InitActionOptions): Promise<void> {
     try {
-      this.simulatorService.setComposeOptions(options.headless, options.disableOllama);
+      this.simulatorService.setComposeOptions(options.headless, options.ollama);
       let localnetVersion = options.localnetVersion;
       if (localnetVersion !== "latest") {
         localnetVersion = this.simulatorService.normalizeLocalnetVersion(localnetVersion);
@@ -89,7 +89,7 @@ export class InitAction extends BaseAction {
           type: "checkbox",
           name: "selectedLlmProviders",
           message: "Select which LLM providers do you want to use:",
-          choices: this.simulatorService.getAiProvidersOptions(true),
+          choices: this.simulatorService.getAiProvidersOptions(true, options.ollama ? [] : ["ollama"]),
           validate: (answer) =>
             answer.length < 1 ? "You must choose at least one option." : true,
         },
@@ -142,7 +142,7 @@ export class InitAction extends BaseAction {
 
       this.stopSpinner();
 
-      if (selectedLlmProviders.includes("ollama") && !options.disableOllama) {
+      if (selectedLlmProviders.includes("ollama")) {
         const ollamaAction = new OllamaAction();
         if (!defaultOllamaModel) {
           this.writeConfig("defaultOllamaModel", "llama3");

--- a/src/commands/general/start.ts
+++ b/src/commands/general/start.ts
@@ -9,7 +9,7 @@ export interface StartActionOptions {
   numValidators: number;
   headless: boolean;
   resetDb: boolean;
-  disableOllama: boolean;
+  ollama: boolean;
 }
 
 export class StartAction extends BaseAction {
@@ -21,9 +21,9 @@ export class StartAction extends BaseAction {
   }
 
   async execute(options: StartActionOptions) {
-    const { resetValidators, numValidators, headless, resetDb, disableOllama } = options;
+    const { resetValidators, numValidators, headless, resetDb, ollama } = options;
 
-    this.simulatorService.setComposeOptions(headless, disableOllama);
+    this.simulatorService.setComposeOptions(headless, ollama);
     this.startSpinner("Checking CLI version...");
     await this.simulatorService.checkCliVersion();
 
@@ -82,7 +82,7 @@ export class StartAction extends BaseAction {
             type: "checkbox",
             name: "selectedLlmProviders",
             message: "Select which LLM providers do you want to use:",
-            choices: this.simulatorService.getAiProvidersOptions(false),
+            choices: this.simulatorService.getAiProvidersOptions(false, ollama ? [] : ["ollama"]),
             validate: (answer) => (answer.length < 1 ? "You must choose at least one option." : true),
           },
         ];

--- a/src/commands/general/start.ts
+++ b/src/commands/general/start.ts
@@ -9,6 +9,7 @@ export interface StartActionOptions {
   numValidators: number;
   headless: boolean;
   resetDb: boolean;
+  disableOllama: boolean;
 }
 
 export class StartAction extends BaseAction {
@@ -20,9 +21,9 @@ export class StartAction extends BaseAction {
   }
 
   async execute(options: StartActionOptions) {
-    const { resetValidators, numValidators, headless, resetDb } = options;
+    const { resetValidators, numValidators, headless, resetDb, disableOllama } = options;
 
-    this.simulatorService.setComposeOptions(headless);
+    this.simulatorService.setComposeOptions(headless, disableOllama);
     this.startSpinner("Checking CLI version...");
     await this.simulatorService.checkCliVersion();
 

--- a/src/commands/update/ollama.ts
+++ b/src/commands/update/ollama.ts
@@ -67,7 +67,7 @@ export class OllamaAction extends BaseAction {
       this.startSpinner(`Executing '${command}' command on model "${modelName}"...`);
 
       let success = false;
-      const ollamaContainer = this.docker.getContainer("ollama");
+      const ollamaContainer = this.docker.getContainer("genlayer-ollama");
       const exec = await ollamaContainer.exec({
         Cmd: ["ollama", command, modelName],
         AttachStdout: true,

--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -2,10 +2,10 @@ export const localnetCompatibleVersion = "v0.51.1";
 export const DEFAULT_JSON_RPC_URL = "http://localhost:4000/api";
 export const CONTAINERS_NAME_PREFIX = "/genlayer-";
 export const IMAGES_NAME_PREFIX = "yeagerai";
-export const DEFAULT_RUN_SIMULATOR_COMMAND = (location: string, options: string) => ({
-  darwin: `osascript -e 'tell application "Terminal" to do script "cd ${location} && docker compose build && docker compose -p genlayer up ${options}"'`,
-  win32: `start cmd.exe /c "cd /d ${location} && docker compose build && docker compose -p genlayer up ${options} && pause"`,
-  linux: `nohup bash -c 'cd ${location} && docker compose build && docker compose -p genlayer up ${options} -d '`,
+export const DEFAULT_RUN_SIMULATOR_COMMAND = (location: string, profiles: string) => ({
+  darwin: `osascript -e 'tell application "Terminal" to do script "cd ${location} && docker compose build && docker compose -p genlayer ${profiles} up"'`,
+  win32: `start cmd.exe /c "cd /d ${location} && docker compose build && docker compose -p genlayer ${profiles} up && pause"`,
+  linux: `nohup bash -c 'cd ${location} && docker compose build && docker compose -p genlayer ${profiles} up -d '`,
 });
 export const DEFAULT_RUN_DOCKER_COMMAND = {
   darwin: "open -a Docker",

--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -1,4 +1,4 @@
-export const localnetCompatibleVersion = "v0.51.1";
+export const localnetCompatibleVersion = "v0.55.0";
 export const DEFAULT_JSON_RPC_URL = "http://localhost:4000/api";
 export const CONTAINERS_NAME_PREFIX = "/genlayer-";
 export const IMAGES_NAME_PREFIX = "yeagerai";

--- a/src/lib/interfaces/ISimulatorService.ts
+++ b/src/lib/interfaces/ISimulatorService.ts
@@ -9,7 +9,7 @@ export interface ISimulatorService {
   waitForSimulatorToBeReady(retries?: number): Promise<WaitForSimulatorToBeReadyResultType>;
   createRandomValidators(numValidators: number, llmProviders: AiProviders[]): Promise<any>;
   deleteAllValidators(): Promise<any>;
-  getAiProvidersOptions(withHint: boolean): Array<{name: string; value: string}>;
+  getAiProvidersOptions(withHint: boolean, excludeProviders?: AiProviders[]): Array<{name: string; value: string}>;
   getFrontendUrl(): string;
   openFrontend(): Promise<boolean>;
   stopDockerContainers(): Promise<void>;

--- a/src/lib/interfaces/ISimulatorService.ts
+++ b/src/lib/interfaces/ISimulatorService.ts
@@ -1,7 +1,7 @@
 import {AiProviders} from "../config/simulator";
 
 export interface ISimulatorService {
-  setComposeOptions(headless: boolean): void;
+  setComposeOptions(headless: boolean, disableOllama?: boolean): void;
   getComposeOptions(): string;
   checkInstallRequirements(): Promise<Record<string, boolean>>;
   checkVersionRequirements(): Promise<Record<string, string>>;

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -62,7 +62,7 @@ export class SimulatorService implements ISimulatorService {
     const containers = await this.docker.listContainers({ all: true });
     return containers.filter(container =>
       container.Names.some(name =>
-        name.startsWith(CONTAINERS_NAME_PREFIX) || name.includes("ollama")
+        name.startsWith(CONTAINERS_NAME_PREFIX)
       )
     );
   }

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -40,14 +40,14 @@ function sleep(millliseconds: number): Promise<void> {
 }
 
 export class SimulatorService implements ISimulatorService {
-  private composeOptions: string
+  private profileOptions: string
   private docker: Docker;
   public location: string;
 
   constructor() {
     const __filename = fileURLToPath(import.meta.url);
     this.location = path.resolve(path.dirname(__filename), '..');
-    this.composeOptions = "";
+    this.profileOptions = "";
     this.docker = new Docker();
   }
 
@@ -104,12 +104,22 @@ export class SimulatorService implements ISimulatorService {
     fs.writeFileSync(envFilePath, updatedConfig);
   }
 
-  public setComposeOptions(headless: boolean): void {
-    this.composeOptions = headless ? '--scale frontend=0' : '';
+  public setComposeOptions(headless: boolean, disableOllama: boolean = false): void {
+    let profiles = [];
+    
+    if (!headless) {
+      profiles.push("frontend");
+    }
+    
+    if (!disableOllama) {
+      profiles.push("ollama");
+    }
+    
+    this.profileOptions = profiles.length > 0 ? `--profile ${profiles.join(" --profile ")}` : "";
   }
 
   public getComposeOptions(): string {
-    return this.composeOptions;
+    return this.profileOptions;
   }
 
   public async checkCliVersion(): Promise<void> {

--- a/src/lib/services/simulator.ts
+++ b/src/lib/services/simulator.ts
@@ -104,14 +104,14 @@ export class SimulatorService implements ISimulatorService {
     fs.writeFileSync(envFilePath, updatedConfig);
   }
 
-  public setComposeOptions(headless: boolean, disableOllama: boolean = false): void {
+  public setComposeOptions(headless: boolean, ollama: boolean = false): void {
     let profiles = [];
     
     if (!headless) {
       profiles.push("frontend");
     }
     
-    if (!disableOllama) {
+    if (ollama) {
       profiles.push("ollama");
     }
     
@@ -237,13 +237,15 @@ export class SimulatorService implements ISimulatorService {
     return rpcClient.request({method: "sim_deleteAllValidators", params: []});
   }
 
-  public getAiProvidersOptions(withHint: boolean = true): Array<{name: string; value: string}> {
-    return Object.values(AI_PROVIDERS_CONFIG).map(providerConfig => {
-      return {
-        name: `${providerConfig.name}${withHint ? ` ${providerConfig.hint}` : ""}`,
-        value: providerConfig.cliOptionValue,
-      };
-    });
+  public getAiProvidersOptions(withHint: boolean = true, excludeProviders: AiProviders[] = []): Array<{name: string; value: string}> {
+    return Object.values(AI_PROVIDERS_CONFIG)
+      .filter(providerConfig => !excludeProviders.includes(providerConfig.cliOptionValue as AiProviders))
+      .map(providerConfig => {
+        return {
+          name: `${providerConfig.name}${withHint ? ` ${providerConfig.hint}` : ""}`,
+          value: providerConfig.cliOptionValue,
+        };
+      });
   }
 
   public getFrontendUrl(): string {

--- a/tests/actions/init.test.ts
+++ b/tests/actions/init.test.ts
@@ -29,6 +29,7 @@ describe("InitAction", () => {
     headless: false,
     resetDb: false,
     localnetVersion: "v1.0.0",
+    ollama: false
   };
 
   beforeEach(() => {
@@ -130,6 +131,7 @@ describe("InitAction", () => {
         headless: true,
         resetDb: true,
         localnetVersion: "v1.0.0",
+        ollama: true
       };
       await initAction.execute(headlessOptions);
       expect(cleanDatabaseSpy).toHaveBeenCalled();
@@ -190,6 +192,30 @@ describe("InitAction", () => {
       await initAction.execute(defaultOptions);
       expect(capturedQuestion.validate([])).toBe("You must choose at least one option.");
       expect(capturedQuestion.validate(["openai"])).toBe(true);
+    });
+
+    test("should exclude ollama from choices when ollama option is false", async () => {
+      const getAiProvidersOptionsSpy = vi.spyOn(SimulatorService.prototype, "getAiProvidersOptions");
+      inquirerPromptSpy
+        .mockResolvedValueOnce({ confirmAction: true })
+        .mockResolvedValueOnce({ selectedLlmProviders: ["openai"] })
+        .mockResolvedValueOnce({ openai: "API_KEY_OPENAI" });
+      
+      await initAction.execute({ ...defaultOptions, ollama: false });
+      
+      expect(getAiProvidersOptionsSpy).toHaveBeenCalledWith(true, ["ollama"]);
+    });
+
+    test("should include ollama in choices when ollama option is true", async () => {
+      const getAiProvidersOptionsSpy = vi.spyOn(SimulatorService.prototype, "getAiProvidersOptions");
+      inquirerPromptSpy
+        .mockResolvedValueOnce({ confirmAction: true })
+        .mockResolvedValueOnce({ selectedLlmProviders: ["openai"] })
+        .mockResolvedValueOnce({ openai: "API_KEY_OPENAI" });
+      
+      await initAction.execute({ ...defaultOptions, ollama: true });
+      
+      expect(getAiProvidersOptionsSpy).toHaveBeenCalledWith(true, []);
     });
   });
 

--- a/tests/actions/ollama.test.ts
+++ b/tests/actions/ollama.test.ts
@@ -70,7 +70,7 @@ describe("OllamaAction", () => {
     await ollamaAction.updateModel("mocked_model");
 
     expect(ollamaAction["startSpinner"]).toHaveBeenCalledWith(`Updating model "mocked_model"...`);
-    expect(mockGetContainer).toHaveBeenCalledWith("ollama");
+    expect(mockGetContainer).toHaveBeenCalledWith("genlayer-ollama");
     expect(mockExec).toHaveBeenCalledWith({
       Cmd: ["ollama", "pull", "mocked_model"],
       AttachStdout: true,
@@ -94,7 +94,7 @@ describe("OllamaAction", () => {
     await ollamaAction.removeModel("mocked_model");
 
     expect(ollamaAction["startSpinner"]).toHaveBeenCalledWith(`Executing 'rm' command on model "mocked_model"...`);
-    expect(mockGetContainer).toHaveBeenCalledWith("ollama");
+    expect(mockGetContainer).toHaveBeenCalledWith("genlayer-ollama");
     expect(mockExec).toHaveBeenCalledWith({
       Cmd: ["ollama", "rm", "mocked_model"],
       AttachStdout: true,

--- a/tests/actions/start.test.ts
+++ b/tests/actions/start.test.ts
@@ -20,6 +20,7 @@ describe("StartAction", () => {
 
     mockSimulatorService.waitForSimulatorToBeReady = vi.fn().mockResolvedValue({ initialized: true });
     mockSimulatorService.stopDockerContainers = vi.fn().mockResolvedValue(undefined);
+    mockSimulatorService.getAiProvidersOptions = vi.fn().mockResolvedValue(undefined);
 
     mockConfirmPrompt = vi.spyOn(startAction as any, "confirmPrompt").mockResolvedValue(undefined);
     vi.spyOn(startAction as any, "startSpinner").mockImplementation(() => {});
@@ -37,6 +38,7 @@ describe("StartAction", () => {
     numValidators: 5,
     headless: false,
     resetDb: false,
+    ollama: false
   };
 
   test("should check if localnet is running and proceed without confirmation when not running", async () => {
@@ -193,5 +195,17 @@ describe("StartAction", () => {
     expect(startAction["succeedSpinner"]).toHaveBeenCalledWith(
       "GenLayer simulator initialized successfully! "
     );
+  });
+
+  test("should exclude ollama from choices when ollama option is false", async () => {
+    await startAction.execute({ ...defaultOptions, resetValidators: true, ollama: false });
+    
+    expect(mockSimulatorService.getAiProvidersOptions).toHaveBeenCalledWith(false, ["ollama"]);
+  });
+
+  test("should include ollama in choices when ollama option is true", async () => {
+    await startAction.execute({ ...defaultOptions, resetValidators: true, ollama: true });
+
+    expect(mockSimulatorService.getAiProvidersOptions).toHaveBeenCalledWith(false, []);
   });
 });

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -15,7 +15,8 @@ const defaultOptions = {
   numValidators: "5",
   headless: false,
   resetDb: false,
-  localnetVersion: localnetCompatibleVersion
+  localnetVersion: localnetCompatibleVersion,
+  disableOllama: false,
 }
 
 vi.mock("inquirer", () => ({
@@ -80,5 +81,11 @@ describe("init command", () => {
     expect(InitAction).toHaveBeenCalledTimes(1);
     expect(InitAction.prototype.execute).toHaveBeenCalledWith({...defaultOptions, localnetVersion: "v1.0.0"});
     expect(openFrontendSpy).not.toHaveBeenCalled();
+  });
+
+  test("option --disable-ollama is accepted", async () => {
+    program.parse(["node", "test", "init", "--disable-ollama"]);
+    expect(InitAction).toHaveBeenCalledTimes(1);
+    expect(InitAction.prototype.execute).toHaveBeenCalledWith({...defaultOptions, disableOllama: true});
   });
 });

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -16,7 +16,7 @@ const defaultOptions = {
   headless: false,
   resetDb: false,
   localnetVersion: localnetCompatibleVersion,
-  disableOllama: false,
+  ollama: false,
 }
 
 vi.mock("inquirer", () => ({
@@ -83,9 +83,9 @@ describe("init command", () => {
     expect(openFrontendSpy).not.toHaveBeenCalled();
   });
 
-  test("option --disable-ollama is accepted", async () => {
-    program.parse(["node", "test", "init", "--disable-ollama"]);
+  test("option --ollama is accepted", async () => {
+    program.parse(["node", "test", "init", "--ollama"]);
     expect(InitAction).toHaveBeenCalledTimes(1);
-    expect(InitAction.prototype.execute).toHaveBeenCalledWith({...defaultOptions, disableOllama: true});
+    expect(InitAction.prototype.execute).toHaveBeenCalledWith({...defaultOptions, ollama: true});
   });
 });

--- a/tests/commands/up.test.ts
+++ b/tests/commands/up.test.ts
@@ -31,7 +31,7 @@ describe("up command", () => {
         numValidators: "5",
         headless: false,
         resetDb: false,
-        disableOllama: false,
+        ollama: false,
       })
     );
   });
@@ -73,7 +73,7 @@ describe("up command", () => {
         numValidators: "5",
         headless: false,
         resetDb: false,
-        disableOllama: false,
+        ollama: false,
       })
     );
   });
@@ -88,7 +88,7 @@ describe("up command", () => {
       "10",
       "--headless",
       "--reset-db",
-      "--disable-ollama",
+      "--ollama",
     ]);
 
     expect(StartAction).toHaveBeenCalledTimes(1);
@@ -98,7 +98,7 @@ describe("up command", () => {
         numValidators: "10",
         headless: true,
         resetDb: true,
-        disableOllama: true,
+        ollama: true,
       })
     );
   });

--- a/tests/commands/up.test.ts
+++ b/tests/commands/up.test.ts
@@ -31,6 +31,7 @@ describe("up command", () => {
         numValidators: "5",
         headless: false,
         resetDb: false,
+        disableOllama: false,
       })
     );
   });
@@ -72,6 +73,7 @@ describe("up command", () => {
         numValidators: "5",
         headless: false,
         resetDb: false,
+        disableOllama: false,
       })
     );
   });
@@ -85,7 +87,8 @@ describe("up command", () => {
       "--numValidators",
       "10",
       "--headless",
-      "--reset-db"
+      "--reset-db",
+      "--disable-ollama",
     ]);
 
     expect(StartAction).toHaveBeenCalledTimes(1);
@@ -95,6 +98,7 @@ describe("up command", () => {
         numValidators: "10",
         headless: true,
         resetDb: true,
+        disableOllama: true,
       })
     );
   });

--- a/tests/services/simulator.test.ts
+++ b/tests/services/simulator.test.ts
@@ -144,25 +144,25 @@ describe("SimulatorService - Basic Tests", () => {
     expect(result).toEqual({ stdout: "Simulator started", stderr: "" });
   });
 
-  test("should execute the correct run simulator command based on disableOllama option", async () => {
+  test("should execute the correct run simulator command based on ollama option", async () => {
     (executeCommand as Mock).mockResolvedValue({
       stdout: "Simulator started",
       stderr: "",
     });
     
-    simulatorService.setComposeOptions(false, false);
+    simulatorService.setComposeOptions(false, true);
     let commandOptions = simulatorService.getComposeOptions();
     expect(commandOptions).toBe("--profile frontend --profile ollama");
     
-    simulatorService.setComposeOptions(true, false);
+    simulatorService.setComposeOptions(true, true);
     commandOptions = simulatorService.getComposeOptions();
     expect(commandOptions).toBe("--profile ollama");
     
-    simulatorService.setComposeOptions(false, true);
+    simulatorService.setComposeOptions(false, false);
     commandOptions = simulatorService.getComposeOptions();
     expect(commandOptions).toBe("--profile frontend");
     
-    simulatorService.setComposeOptions(true, true);
+    simulatorService.setComposeOptions(true, false);
     commandOptions = simulatorService.getComposeOptions();
     expect(commandOptions).toBe("");
     
@@ -302,6 +302,37 @@ describe("SimulatorService - Basic Tests", () => {
   test("should return providers without errors", () => {
     expect(simulatorService.getAiProvidersOptions(true)).toEqual(expect.any(Array));
     expect(simulatorService.getAiProvidersOptions(false)).toEqual(expect.any(Array));
+  });
+
+  test("should exclude specified providers from the options list", () => {
+    const allProviders = simulatorService.getAiProvidersOptions(false);
+    const providersWithoutOllama = simulatorService.getAiProvidersOptions(false, ["ollama"]);
+    
+    // Check that the list without Ollama is shorter
+    expect(providersWithoutOllama.length).toBeLessThan(allProviders.length);
+    
+    // Verify Ollama is not in the filtered list
+    const ollamaProvider = providersWithoutOllama.find(p => p.value === "ollama");
+    expect(ollamaProvider).toBeUndefined();
+    
+    // Verify other providers are still present
+    const openaiProvider = providersWithoutOllama.find(p => p.value === "openai");
+    expect(openaiProvider).toBeDefined();
+  });
+
+  test("should exclude multiple providers when specified", () => {
+    const providersWithoutMultiple = simulatorService.getAiProvidersOptions(false, ["ollama", "openai"]);
+    
+    // Verify excluded providers are not in the list
+    const ollamaProvider = providersWithoutMultiple.find(p => p.value === "ollama");
+    const openaiProvider = providersWithoutMultiple.find(p => p.value === "openai");
+    
+    expect(ollamaProvider).toBeUndefined();
+    expect(openaiProvider).toBeUndefined();
+    
+    // Verify other providers are still present
+    const heuristaiProvider = providersWithoutMultiple.find(p => p.value === "heuristai");
+    expect(heuristaiProvider).toBeDefined();
   });
 
   test("clean simulator should success", async () => {

--- a/tests/services/simulator.test.ts
+++ b/tests/services/simulator.test.ts
@@ -144,6 +144,33 @@ describe("SimulatorService - Basic Tests", () => {
     expect(result).toEqual({ stdout: "Simulator started", stderr: "" });
   });
 
+  test("should execute the correct run simulator command based on disableOllama option", async () => {
+    (executeCommand as Mock).mockResolvedValue({
+      stdout: "Simulator started",
+      stderr: "",
+    });
+    
+    simulatorService.setComposeOptions(false, false);
+    let commandOptions = simulatorService.getComposeOptions();
+    expect(commandOptions).toBe("--profile frontend --profile ollama");
+    
+    simulatorService.setComposeOptions(true, false);
+    commandOptions = simulatorService.getComposeOptions();
+    expect(commandOptions).toBe("--profile ollama");
+    
+    simulatorService.setComposeOptions(false, true);
+    commandOptions = simulatorService.getComposeOptions();
+    expect(commandOptions).toBe("--profile frontend");
+    
+    simulatorService.setComposeOptions(true, true);
+    commandOptions = simulatorService.getComposeOptions();
+    expect(commandOptions).toBe("");
+    
+    await simulatorService.runSimulator();
+    const expectedCommand = DEFAULT_RUN_SIMULATOR_COMMAND(simulatorService.location, commandOptions);
+    expect(executeCommand).toHaveBeenCalledWith(expectedCommand);
+  });
+
   test("should create a backup of the .env file and add new config", () => {
     const envFilePath = `/.env`;
     const originalEnvContent = "KEY1=value1\nKEY2=value2";

--- a/tests/services/simulator.test.ts
+++ b/tests/services/simulator.test.ts
@@ -308,14 +308,11 @@ describe("SimulatorService - Basic Tests", () => {
     const allProviders = simulatorService.getAiProvidersOptions(false);
     const providersWithoutOllama = simulatorService.getAiProvidersOptions(false, ["ollama"]);
     
-    // Check that the list without Ollama is shorter
     expect(providersWithoutOllama.length).toBeLessThan(allProviders.length);
     
-    // Verify Ollama is not in the filtered list
     const ollamaProvider = providersWithoutOllama.find(p => p.value === "ollama");
     expect(ollamaProvider).toBeUndefined();
     
-    // Verify other providers are still present
     const openaiProvider = providersWithoutOllama.find(p => p.value === "openai");
     expect(openaiProvider).toBeDefined();
   });
@@ -323,14 +320,12 @@ describe("SimulatorService - Basic Tests", () => {
   test("should exclude multiple providers when specified", () => {
     const providersWithoutMultiple = simulatorService.getAiProvidersOptions(false, ["ollama", "openai"]);
     
-    // Verify excluded providers are not in the list
     const ollamaProvider = providersWithoutMultiple.find(p => p.value === "ollama");
     const openaiProvider = providersWithoutMultiple.find(p => p.value === "openai");
     
     expect(ollamaProvider).toBeUndefined();
     expect(openaiProvider).toBeUndefined();
     
-    // Verify other providers are still present
     const heuristaiProvider = providersWithoutMultiple.find(p => p.value === "heuristai");
     expect(heuristaiProvider).toBeDefined();
   });


### PR DESCRIPTION
# PR: GenLayer CLI - Add profiles support for frontend and ollama services

This PR improves flexibility in the GenLayer CLI by allowing users to selectively enable or disable the frontend UI and Ollama container when running the localnet.

## Changes

- Updated `docker-compose.yml` to use profiles for the frontend and ollama services
- Added a new `ollama` flag to both `init` and `up` commands
- Refactored `setComposeOptions` in `SimulatorService` to:
  - Use Docker Compose profiles instead of scaling containers
  - Support enabling/disabling services based on user preferences
- Made the ollama dependency optional for the webrequest service
- Updated command implementation to respect profile settings
- Added comprehensive test coverage for all changes

## Why

Previously, the CLI would only allow toggling the frontend with the `--headless` option. This change makes the system more flexible by:

- Allowing users to run the localnet without Ollama, which can be resource-intensive
- Using Docker Compose profiles for cleaner service management
- Making services more modular and independent
- Reducing resource usage when specific components aren't needed

## Testing

Added unit tests to cover:
- Profile generation for all combinations of options
- Command execution with the correct profile parameters
- All tests pass successfully
