### PR TITLE
Cristiam/dxp 353 add command to select network

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^16.4.5",
         "ethers": "^6.13.4",
         "fs-extra": "^11.3.0",
-        "genlayer-js": "^0.9.0",
+        "genlayer-js": "^0.11.0",
         "inquirer": "^12.0.0",
         "node-fetch": "^3.0.0",
         "open": "^10.1.0",
@@ -1097,6 +1097,18 @@
         "@tybys/wasm-util": "^0.9.0"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -1485,35 +1497,35 @@
       "license": "MIT"
     },
     "node_modules/@scure/base": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
-      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.5.tgz",
+      "integrity": "sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
-      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.8.1",
-        "@noble/hashes": "~1.7.1",
-        "@scure/base": "~1.2.2"
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1523,9 +1535,9 @@
       }
     },
     "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1535,22 +1547,22 @@
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
-      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.7.1",
-        "@scure/base": "~1.2.4"
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -4900,14 +4912,14 @@
       }
     },
     "node_modules/genlayer-js": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.9.0.tgz",
-      "integrity": "sha512-PBG9k7g9/uvl33DIs9bVTb+bdaHnbmXwphsh4fAUmv5CLTLKQtfLqQ7+OXFFVq56txs9geldr+g7ulgd8YtCGQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.11.0.tgz",
+      "integrity": "sha512-AOITeryimIYjwXXg/S6Lig9PRSFmtR8aY0K8BCX+9JXMDrCaWPiMDHYYw+xcXhUsry78DtX2oXwuwA0N5HSSiA==",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",
         "typescript-parsec": "^0.3.4",
-        "viem": "^2.21.7"
+        "viem": "^2.29.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -5969,9 +5981,9 @@
       "license": "ISC"
     },
     "node_modules/isows": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
-      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
       "funding": [
         {
           "type": "github",
@@ -6981,9 +6993,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
-      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.7.1.tgz",
+      "integrity": "sha512-+k9fY9PRNuAMHRFIUbiK9Nt5seYHHzSQs9Bj+iMETcGtlpS7SmBzcGSVUQO3+nqGLEiNK4598pHNFlVRaZbRsg==",
       "funding": [
         {
           "type": "github",
@@ -6993,6 +7005,7 @@
       "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/ciphers": "^1.3.0",
         "@noble/curves": "^1.6.0",
         "@noble/hashes": "^1.5.0",
         "@scure/bip32": "^1.5.0",
@@ -7010,12 +7023,12 @@
       }
     },
     "node_modules/ox/node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -7025,9 +7038,9 @@
       }
     },
     "node_modules/ox/node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -9179,9 +9192,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.23.6",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.6.tgz",
-      "integrity": "sha512-+yUeK8rktbGFQaLIvY4Tki22HUjian9Z4eKGAUT72RF9bcfkYgK8CJZz9P83tgoeLpiTyX3xcBM4xJZrJyKmsA==",
+      "version": "2.30.5",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.30.5.tgz",
+      "integrity": "sha512-YymUl7AKsIw3BhQLZxr3j+g8OwqsxmV3xu7zDMmmuFACtvQ3YZaFsKrH7N8eTXpPHYgMlClvKIjgXS8Twt+sQQ==",
       "funding": [
         {
           "type": "github",
@@ -9190,14 +9203,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "1.8.1",
-        "@noble/hashes": "1.7.1",
-        "@scure/bip32": "1.6.2",
-        "@scure/bip39": "1.5.4",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
         "abitype": "1.0.8",
-        "isows": "1.0.6",
-        "ox": "0.6.7",
-        "ws": "8.18.0"
+        "isows": "1.0.7",
+        "ox": "0.7.1",
+        "ws": "8.18.2"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -9209,12 +9222,12 @@
       }
     },
     "node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -9224,9 +9237,9 @@
       }
     },
     "node_modules/viem/node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -9236,9 +9249,9 @@
       }
     },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.4.5",
     "ethers": "^6.13.4",
     "fs-extra": "^11.3.0",
-    "genlayer-js": "^0.9.0",
+    "genlayer-js": "^0.11.0",
     "inquirer": "^12.0.0",
     "node-fetch": "^3.0.0",
     "open": "^10.1.0",

--- a/src/commands/contracts/deploy.ts
+++ b/src/commands/contracts/deploy.ts
@@ -1,11 +1,9 @@
 import fs from "fs";
 import path from "path";
-import { simulator } from "genlayer-js/chains";
-import type { GenLayerClient } from "genlayer-js/types";
-import { BaseAction } from "../../lib/actions/BaseAction";
-import { pathToFileURL } from "url";
-import { TransactionStatus } from "genlayer-js/types";
-import { buildSync } from "esbuild";
+import {BaseAction} from "../../lib/actions/BaseAction";
+import {pathToFileURL} from "url";
+import {TransactionStatus} from "genlayer-js/types";
+import {buildSync} from "esbuild";
 
 export interface DeployOptions {
   contract?: string;
@@ -44,7 +42,7 @@ export class DeployAction extends BaseAction {
         target: "es2020",
         sourcemap: false,
       });
-     await this.executeJsScript(filePath, outFile, rpcUrl);
+      await this.executeJsScript(filePath, outFile, rpcUrl);
     } catch (error) {
       this.failSpinner(`Error executing: ${filePath}`, error);
     } finally {
@@ -52,13 +50,17 @@ export class DeployAction extends BaseAction {
     }
   }
 
-  private async executeJsScript(filePath: string, transpiledFilePath?: string, rpcUrl?: string): Promise<void> {
+  private async executeJsScript(
+    filePath: string,
+    transpiledFilePath?: string,
+    rpcUrl?: string,
+  ): Promise<void> {
     this.startSpinner(`Executing file: ${filePath}`);
     try {
       const module = await import(pathToFileURL(transpiledFilePath || filePath).href);
       if (!module.default || typeof module.default !== "function") {
         this.failSpinner(`No "default" function found in: ${filePath}`);
-        return
+        return;
       }
       const client = await this.getClient(rpcUrl);
       await module.default(client);
@@ -74,7 +76,8 @@ export class DeployAction extends BaseAction {
       this.failSpinner("No deploy folder found.");
       return;
     }
-    const files = fs.readdirSync(this.deployDir)
+    const files = fs
+      .readdirSync(this.deployDir)
       .filter(file => file.endsWith(".ts") || file.endsWith(".js"))
       .sort((a, b) => {
         const numA = parseInt(a.split("_")[0]);
@@ -127,7 +130,7 @@ export class DeployAction extends BaseAction {
       }
 
       const leaderOnly = false;
-      const deployParams: any = { code: contractCode, args: options.args, leaderOnly };
+      const deployParams: any = {code: contractCode, args: options.args, leaderOnly};
 
       this.setSpinnerText("Starting contract deployment...");
       this.log("Deployment Parameters:", deployParams);

--- a/src/commands/network/index.ts
+++ b/src/commands/network/index.ts
@@ -1,0 +1,14 @@
+import {Command} from "commander";
+import {NetworkActions} from "./setNetwork";
+
+export function initializeNetworkCommands(program: Command) {
+  const networkActions = new NetworkActions();
+
+  program
+    .command("network")
+    .description("Set the network to use")
+    .argument("[network]", "The network to use")
+    .action((networkName?: string) => networkActions.setNetwork(networkName));
+
+  return program;
+}

--- a/src/commands/network/setNetwork.ts
+++ b/src/commands/network/setNetwork.ts
@@ -1,0 +1,60 @@
+import {AiProviders} from "@/lib/config/simulator";
+import {BaseAction} from "../../lib/actions/BaseAction";
+import inquirer, {DistinctQuestion} from "inquirer";
+import {localnet, studionet, testnetAsimov} from "genlayer-js/chains";
+import {} from "genlayer-js/chains";
+
+const networks = [
+  {
+    name: localnet.name,
+    alias: "localnet",
+    value: localnet,
+  },
+  {
+    name: studionet.name,
+    alias: "studionet",
+    value: studionet,
+  },
+  {
+    name: testnetAsimov.name,
+    alias: "testnet-asimov",
+    value: testnetAsimov,
+  },
+];
+
+export class NetworkActions extends BaseAction {
+  constructor() {
+    super();
+  }
+
+  async setNetwork(networkName?: string): Promise<void> {
+    if (networkName) {
+      if (!networks.some(n => n.name === networkName || n.alias === networkName)) {
+        this.failSpinner(`Network ${networkName} not found`);
+        return;
+      }
+      const selectedNetwork = networks.find(n => n.name === networkName || n.alias === networkName);
+      if (!selectedNetwork) {
+        this.failSpinner(`Network ${networkName} not found`);
+        return;
+      }
+      this.writeConfig("network", JSON.stringify(selectedNetwork));
+      this.succeedSpinner(`Network successfully set to ${selectedNetwork.name}`);
+      return;
+    }
+
+    const networkQuestions: DistinctQuestion[] = [
+      {
+        type: "list",
+        name: "selectedNetwork",
+        message: "Select which network do you want to use:",
+        choices: networks,
+      },
+    ];
+    const networkAnswer = await inquirer.prompt(networkQuestions);
+    const selectedNetwork = networkAnswer.selectedNetwork;
+
+    this.writeConfig("network", JSON.stringify(selectedNetwork));
+    this.succeedSpinner(`Network successfully set to ${selectedNetwork.name}`);
+  }
+}

--- a/src/commands/network/setNetwork.ts
+++ b/src/commands/network/setNetwork.ts
@@ -28,7 +28,7 @@ export class NetworkActions extends BaseAction {
   }
 
   async setNetwork(networkName?: string): Promise<void> {
-    if (networkName) {
+    if (networkName || networkName === "") {
       if (!networks.some(n => n.name === networkName || n.alias === networkName)) {
         this.failSpinner(`Network ${networkName} not found`);
         return;
@@ -38,7 +38,7 @@ export class NetworkActions extends BaseAction {
         this.failSpinner(`Network ${networkName} not found`);
         return;
       }
-      this.writeConfig("network", JSON.stringify(selectedNetwork));
+      this.writeConfig("network", JSON.stringify(selectedNetwork.value));
       this.succeedSpinner(`Network successfully set to ${selectedNetwork.name}`);
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,14 @@
 import {program} from "commander";
 import {version} from "../package.json";
 import {CLI_DESCRIPTION} from "../src/lib/config/text";
-import { initializeGeneralCommands } from "../src/commands/general";
-import { initializeKeygenCommands } from "../src/commands/keygen";
-import { initializeContractsCommands } from "../src/commands/contracts";
-import { initializeConfigCommands } from "../src/commands/config";
+import {initializeGeneralCommands} from "../src/commands/general";
+import {initializeKeygenCommands} from "../src/commands/keygen";
+import {initializeContractsCommands} from "../src/commands/contracts";
+import {initializeConfigCommands} from "../src/commands/config";
 import {initializeValidatorCommands} from "../src/commands/validators";
-import { initializeUpdateCommands } from "../src/commands/update";
-import { initializeScaffoldCommands } from "../src/commands/scaffold";
+import {initializeUpdateCommands} from "../src/commands/update";
+import {initializeScaffoldCommands} from "../src/commands/scaffold";
+import {initializeNetworkCommands} from "../src/commands/network";
 
 export function initializeCLI() {
   program.version(version).description(CLI_DESCRIPTION);
@@ -16,9 +17,10 @@ export function initializeCLI() {
   initializeKeygenCommands(program);
   initializeContractsCommands(program);
   initializeConfigCommands(program);
-  initializeUpdateCommands(program)
+  initializeUpdateCommands(program);
   initializeValidatorCommands(program);
   initializeScaffoldCommands(program);
+  initializeNetworkCommands(program);
   program.parse(process.argv);
 }
 

--- a/src/lib/actions/BaseAction.ts
+++ b/src/lib/actions/BaseAction.ts
@@ -1,29 +1,31 @@
-import { ConfigFileManager } from "../../lib/config/ConfigFileManager";
-import ora, { Ora } from "ora";
+import {ConfigFileManager} from "../../lib/config/ConfigFileManager";
+import ora, {Ora} from "ora";
 import chalk from "chalk";
 import inquirer from "inquirer";
-import { KeypairManager } from "../accounts/KeypairManager";
-import { createClient, createAccount } from "genlayer-js";
-import { localnet } from "genlayer-js/chains";
-import type { GenLayerClient } from "genlayer-js/types";
+import {KeypairManager} from "../accounts/KeypairManager";
+import {createClient, createAccount} from "genlayer-js";
+import {localnet} from "genlayer-js/chains";
+import type {GenLayerClient, GenLayerChain} from "genlayer-js/types";
 
 export class BaseAction extends ConfigFileManager {
   protected keypairManager: KeypairManager;
   private spinner: Ora;
-  private _genlayerClient: GenLayerClient<typeof localnet> | null = null;
+  private _genlayerClient: GenLayerClient<GenLayerChain> | null = null;
 
   constructor() {
-    super()
-    this.spinner = ora({ text: "", spinner: "dots" });
+    super();
+    this.spinner = ora({text: "", spinner: "dots"});
     this.keypairManager = new KeypairManager();
   }
 
-  protected async getClient(rpcUrl?: string): Promise<GenLayerClient<typeof localnet>> {
+  protected async getClient(rpcUrl?: string): Promise<GenLayerClient<GenLayerChain>> {
     if (!this._genlayerClient) {
+      const networkConfig = this.getConfig().network;
+      const network = networkConfig ? JSON.parse(networkConfig) : localnet;
       this._genlayerClient = createClient({
-        chain: localnet,
+        chain: network,
         endpoint: rpcUrl,
-        account: createAccount(await this.getPrivateKey() as any),
+        account: createAccount((await this.getPrivateKey()) as any),
       });
     }
     return this._genlayerClient;
@@ -64,11 +66,11 @@ export class BaseAction extends ConfigFileManager {
       };
       return JSON.stringify(errorDetails, null, 2);
     }
-    
+
     if (data instanceof Map) {
       data = Object.fromEntries(data);
     }
-    
+
     return typeof data === "object" ? JSON.stringify(data, null, 2) : String(data);
   }
 
@@ -103,12 +105,12 @@ export class BaseAction extends ConfigFileManager {
   }
 
   protected succeedSpinner(message: string, data?: any): void {
-    if (data !== undefined) this.log('Result:', data);
+    if (data !== undefined) this.log("Result:", data);
     this.spinner.succeed(chalk.green(message));
   }
 
-  protected failSpinner(message: string, error?:any): void {
-    if (error) this.log('Error:', error);
+  protected failSpinner(message: string, error?: any): void {
+    if (error) this.log("Error:", error);
     this.spinner.fail(chalk.red(message));
   }
 

--- a/tests/actions/deploy.test.ts
+++ b/tests/actions/deploy.test.ts
@@ -1,9 +1,9 @@
-import { describe, test, vi, beforeEach, afterEach, expect } from "vitest";
+import {describe, test, vi, beforeEach, afterEach, expect} from "vitest";
 import fs from "fs";
-import { createClient, createAccount } from "genlayer-js";
-import { DeployAction, DeployOptions } from "../../src/commands/contracts/deploy";
-import { buildSync } from "esbuild";
-import { pathToFileURL } from "url";
+import {createClient, createAccount} from "genlayer-js";
+import {DeployAction, DeployOptions} from "../../src/commands/contracts/deploy";
+import {buildSync} from "esbuild";
+import {pathToFileURL} from "url";
 
 vi.mock("fs");
 vi.mock("genlayer-js");
@@ -24,9 +24,10 @@ describe("DeployAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(createClient).mockReturnValue(mockClient as any);
-    vi.mocked(createAccount).mockReturnValue({ privateKey: mockPrivateKey } as any);
+    vi.mocked(createAccount).mockReturnValue({privateKey: mockPrivateKey} as any);
     deployer = new DeployAction();
     vi.spyOn(deployer as any, "getPrivateKey").mockResolvedValue(mockPrivateKey);
+    vi.spyOn(deployer as any, "getConfig").mockReturnValue({});
 
     vi.spyOn(deployer as any, "startSpinner").mockImplementation(() => {});
     vi.spyOn(deployer as any, "succeedSpinner").mockImplementation(() => {});
@@ -57,7 +58,7 @@ describe("DeployAction", () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
     expect(() => deployer["readContractCode"](contractPath)).toThrowError(
-      `Contract file not found: ${contractPath}`
+      `Contract file not found: ${contractPath}`,
     );
     expect(fs.existsSync).toHaveBeenCalledWith(contractPath);
   });
@@ -73,7 +74,7 @@ describe("DeployAction", () => {
     vi.mocked(fs.readFileSync).mockReturnValue(contractContent);
     vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
-      data: { contract_address: "0xdasdsadasdasdada" },
+      data: {contract_address: "0xdasdsadasdasdada"},
     });
 
     await deployer.deploy(options);
@@ -105,9 +106,7 @@ describe("DeployAction", () => {
 
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(contractContent);
-    vi.mocked(mockClient.deployContract).mockRejectedValue(
-      new Error("Mocked deployment error")
-    );
+    vi.mocked(mockClient.deployContract).mockRejectedValue(new Error("Mocked deployment error"));
 
     await deployer.deploy(options);
 
@@ -131,11 +130,7 @@ describe("DeployAction", () => {
 
   test("deployScripts executes scripts in order", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readdirSync).mockReturnValue([
-      "1_first.ts",
-      "2_second.js",
-      "10_last.ts",
-    ] as any);
+    vi.mocked(fs.readdirSync).mockReturnValue(["1_first.ts", "2_second.js", "10_last.ts"] as any);
 
     vi.spyOn(deployer as any, "executeTsScript").mockResolvedValue(undefined);
     vi.spyOn(deployer as any, "executeJsScript").mockResolvedValue(undefined);
@@ -144,7 +139,11 @@ describe("DeployAction", () => {
 
     expect(deployer["setSpinnerText"]).toHaveBeenCalledWith("Found 3 deploy scripts. Executing...");
     expect(deployer["executeTsScript"]).toHaveBeenCalledWith(expect.stringMatching(/1_first.ts/), undefined);
-    expect(deployer["executeJsScript"]).toHaveBeenCalledWith(expect.stringMatching(/2_second.js/), undefined, undefined);
+    expect(deployer["executeJsScript"]).toHaveBeenCalledWith(
+      expect.stringMatching(/2_second.js/),
+      undefined,
+      undefined,
+    );
     expect(deployer["executeTsScript"]).toHaveBeenCalledWith(expect.stringMatching(/10_last.ts/), undefined);
   });
 
@@ -182,20 +181,26 @@ describe("DeployAction", () => {
 
   test("deployScripts sorts and executes scripts correctly", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readdirSync).mockReturnValue([
-      "10_last.ts",
-      "2_second.js",
-      "1_first.ts"
-    ] as any);
+    vi.mocked(fs.readdirSync).mockReturnValue(["10_last.ts", "2_second.js", "1_first.ts"] as any);
 
     vi.spyOn(deployer as any, "executeTsScript").mockResolvedValue(undefined);
     vi.spyOn(deployer as any, "executeJsScript").mockResolvedValue(undefined);
 
     await deployer.deployScripts();
 
-    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(expect.stringContaining("1_first.ts"), undefined);
-    expect(deployer["executeJsScript"]).toHaveBeenCalledWith(expect.stringContaining("2_second.js"), undefined, undefined);
-    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(expect.stringContaining("10_last.ts"), undefined);
+    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(
+      expect.stringContaining("1_first.ts"),
+      undefined,
+    );
+    expect(deployer["executeJsScript"]).toHaveBeenCalledWith(
+      expect.stringContaining("2_second.js"),
+      undefined,
+      undefined,
+    );
+    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(
+      expect.stringContaining("10_last.ts"),
+      undefined,
+    );
   });
 
   test("deployScripts fails when no scripts are found", async () => {
@@ -216,7 +221,7 @@ describe("DeployAction", () => {
 
     expect(deployer["failSpinner"]).toHaveBeenCalledWith(
       expect.stringContaining("Error executing script:"),
-      expect.any(Error)
+      expect.any(Error),
     );
   });
 
@@ -227,12 +232,12 @@ describe("DeployAction", () => {
 
     expect(deployer["failSpinner"]).toHaveBeenCalledWith(
       expect.stringContaining("Error executing:"),
-      expect.any(Error)
+      expect.any(Error),
     );
   });
 
   test("deploy fails when contract code is empty", async () => {
-    const options: DeployOptions = { contract: "/mocked/contract/path" };
+    const options: DeployOptions = {contract: "/mocked/contract/path"};
 
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue("");
@@ -249,7 +254,7 @@ describe("DeployAction", () => {
       "2alpha_script.ts",
       "3alpha_script.ts",
       "blpha_script.ts",
-      "clpha_script.ts"
+      "clpha_script.ts",
     ] as any);
 
     vi.spyOn(deployer as any, "executeTsScript").mockResolvedValue(undefined);
@@ -258,21 +263,33 @@ describe("DeployAction", () => {
     await deployer.deployScripts();
 
     expect(deployer["executeTsScript"]).toHaveBeenCalledWith(expect.stringContaining("script.ts"), undefined);
-    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(expect.stringContaining("2alpha_script.ts"), undefined);
-    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(expect.stringContaining("3alpha_script.ts"), undefined);
-    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(expect.stringContaining("blpha_script.ts"), undefined);
-    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(expect.stringContaining("clpha_script.ts"), undefined);
+    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(
+      expect.stringContaining("2alpha_script.ts"),
+      undefined,
+    );
+    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(
+      expect.stringContaining("3alpha_script.ts"),
+      undefined,
+    );
+    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(
+      expect.stringContaining("blpha_script.ts"),
+      undefined,
+    );
+    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(
+      expect.stringContaining("clpha_script.ts"),
+      undefined,
+    );
   });
 
   test("executeJsScript fails if module has no default export", async () => {
     const filePath = "/mocked/script.js";
 
-    vi.doMock(pathToFileURL(filePath).href, () => ({ default: "Not a function" }));
+    vi.doMock(pathToFileURL(filePath).href, () => ({default: "Not a function"}));
 
     await deployer["executeJsScript"](filePath);
 
     expect(deployer["failSpinner"]).toHaveBeenCalledWith(
-      expect.stringContaining("No \"default\" function found in:"),
+      expect.stringContaining('No "default" function found in:'),
     );
   });
 
@@ -280,7 +297,7 @@ describe("DeployAction", () => {
     const filePath = "/mocked/script.js";
     const mockFn = vi.fn(); // This mock function simulates the script execution
 
-    vi.doMock(pathToFileURL(filePath).href, () => ({ default: mockFn }));
+    vi.doMock(pathToFileURL(filePath).href, () => ({default: mockFn}));
 
     await deployer["executeJsScript"](filePath);
 
@@ -299,17 +316,14 @@ describe("DeployAction", () => {
 
     await deployer["executeTsScript"](filePath);
 
-    expect(deployer["failSpinner"]).toHaveBeenCalledWith(
-      `Error executing: ${filePath}`,
-      error
-    );
+    expect(deployer["failSpinner"]).toHaveBeenCalledWith(`Error executing: ${filePath}`, error);
   });
 
   test("deploys contract with rpc option", async () => {
     const options: DeployOptions = {
       contract: "/mocked/contract/path",
       args: [1, 2, 3],
-      rpc: "https://custom-rpc-url.com"
+      rpc: "https://custom-rpc-url.com",
     };
     const contractContent = "contract code";
 
@@ -317,14 +331,16 @@ describe("DeployAction", () => {
     vi.mocked(fs.readFileSync).mockReturnValue(contractContent);
     vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
-      data: { contract_address: "0xdasdsadasdasdada" },
+      data: {contract_address: "0xdasdsadasdasdada"},
     });
 
     await deployer.deploy(options);
 
-    expect(createClient).toHaveBeenCalledWith(expect.objectContaining({
-      endpoint: "https://custom-rpc-url.com"
-    }));
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: "https://custom-rpc-url.com",
+      }),
+    );
     expect(fs.readFileSync).toHaveBeenCalledWith(options.contract, "utf-8");
     expect(mockClient.deployContract).toHaveBeenCalledWith({
       code: contractContent,
@@ -338,13 +354,15 @@ describe("DeployAction", () => {
     const rpcUrl = "https://custom-rpc-url.com";
     const mockFn = vi.fn();
 
-    vi.doMock(pathToFileURL(filePath).href, () => ({ default: mockFn }));
+    vi.doMock(pathToFileURL(filePath).href, () => ({default: mockFn}));
 
     await deployer["executeJsScript"](filePath, undefined, rpcUrl);
 
-    expect(createClient).toHaveBeenCalledWith(expect.objectContaining({
-      endpoint: rpcUrl
-    }));
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: rpcUrl,
+      }),
+    );
     expect(mockFn).toHaveBeenCalledWith(mockClient);
     expect(deployer["succeedSpinner"]).toHaveBeenCalledWith(`Successfully executed: ${filePath}`);
   });
@@ -376,26 +394,20 @@ describe("DeployAction", () => {
 
   test("deployScripts passes rpc url to script execution methods", async () => {
     const rpcUrl = "https://custom-rpc-url.com";
-    
+
     vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readdirSync).mockReturnValue([
-      "1_first.ts",
-      "2_second.js",
-    ] as any);
+    vi.mocked(fs.readdirSync).mockReturnValue(["1_first.ts", "2_second.js"] as any);
 
     vi.spyOn(deployer as any, "executeTsScript").mockResolvedValue(undefined);
     vi.spyOn(deployer as any, "executeJsScript").mockResolvedValue(undefined);
 
-    await deployer.deployScripts({ rpc: rpcUrl });
+    await deployer.deployScripts({rpc: rpcUrl});
 
-    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(
-      expect.stringMatching(/1_first.ts/),
-      rpcUrl
-    );
+    expect(deployer["executeTsScript"]).toHaveBeenCalledWith(expect.stringMatching(/1_first.ts/), rpcUrl);
     expect(deployer["executeJsScript"]).toHaveBeenCalledWith(
       expect.stringMatching(/2_second.js/),
       undefined,
-      rpcUrl
+      rpcUrl,
     );
   });
 });

--- a/tests/actions/setNetwork.test.ts
+++ b/tests/actions/setNetwork.test.ts
@@ -1,0 +1,199 @@
+import {describe, test, vi, beforeEach, afterEach, expect} from "vitest";
+import {NetworkActions} from "../../src/commands/network/setNetwork";
+import {ConfigFileManager} from "../../src/lib/config/ConfigFileManager";
+import inquirer from "inquirer";
+import {localnet, studionet, testnetAsimov} from "genlayer-js/chains";
+
+vi.mock("../../src/lib/config/ConfigFileManager");
+vi.mock("inquirer");
+
+describe("NetworkActions", () => {
+  let networkActions: NetworkActions;
+
+  beforeEach(() => {
+    networkActions = new NetworkActions();
+    vi.clearAllMocks();
+
+    vi.spyOn(networkActions as any, "succeedSpinner").mockImplementation(() => {});
+    vi.spyOn(networkActions as any, "failSpinner").mockImplementation(() => {});
+    vi.spyOn(networkActions as any, "writeConfig").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("setNetwork method sets network by valid name", async () => {
+    await networkActions.setNetwork(localnet.name);
+
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith("network", JSON.stringify(localnet));
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${localnet.name}`,
+    );
+  });
+
+  test("setNetwork method sets network by valid alias", async () => {
+    await networkActions.setNetwork("localnet");
+
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith("network", JSON.stringify(localnet));
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${localnet.name}`,
+    );
+  });
+
+  test("setNetwork method sets studionet by name", async () => {
+    await networkActions.setNetwork(studionet.name);
+
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith("network", JSON.stringify(studionet));
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${studionet.name}`,
+    );
+  });
+
+  test("setNetwork method sets studionet by alias", async () => {
+    await networkActions.setNetwork("studionet");
+
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith("network", JSON.stringify(studionet));
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${studionet.name}`,
+    );
+  });
+
+  test("setNetwork method sets testnet-asimov by name", async () => {
+    await networkActions.setNetwork(testnetAsimov.name);
+
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith("network", JSON.stringify(testnetAsimov));
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${testnetAsimov.name}`,
+    );
+  });
+
+  test("setNetwork method sets testnet-asimov by alias", async () => {
+    await networkActions.setNetwork("testnet-asimov");
+
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith("network", JSON.stringify(testnetAsimov));
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${testnetAsimov.name}`,
+    );
+  });
+
+  test("setNetwork method fails for invalid network name", async () => {
+    await networkActions.setNetwork("invalidNetwork");
+
+    expect(networkActions["failSpinner"]).toHaveBeenCalledWith("Network invalidNetwork not found");
+    expect(networkActions["writeConfig"]).not.toHaveBeenCalled();
+    expect(networkActions["succeedSpinner"]).not.toHaveBeenCalled();
+  });
+
+  test("setNetwork method fails for empty network name", async () => {
+    await networkActions.setNetwork("");
+
+    expect(networkActions["failSpinner"]).toHaveBeenCalledWith("Network  not found");
+    expect(networkActions["writeConfig"]).not.toHaveBeenCalled();
+    expect(networkActions["succeedSpinner"]).not.toHaveBeenCalled();
+  });
+
+  test("setNetwork method prompts user when no network name provided", async () => {
+    const mockSelectedNetwork = {
+      name: localnet.name,
+      alias: "localnet",
+      value: localnet,
+    };
+
+    vi.mocked(inquirer.prompt).mockResolvedValue({
+      selectedNetwork: mockSelectedNetwork,
+    });
+
+    await networkActions.setNetwork();
+
+    expect(inquirer.prompt).toHaveBeenCalledWith([
+      {
+        type: "list",
+        name: "selectedNetwork",
+        message: "Select which network do you want to use:",
+        choices: [
+          {
+            name: localnet.name,
+            alias: "localnet",
+            value: localnet,
+          },
+          {
+            name: studionet.name,
+            alias: "studionet",
+            value: studionet,
+          },
+          {
+            name: testnetAsimov.name,
+            alias: "testnet-asimov",
+            value: testnetAsimov,
+          },
+        ],
+      },
+    ]);
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith(
+      "network",
+      JSON.stringify(mockSelectedNetwork),
+    );
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${mockSelectedNetwork.name}`,
+    );
+  });
+
+  test("setNetwork method handles interactive selection of studionet", async () => {
+    const mockSelectedNetwork = {
+      name: studionet.name,
+      alias: "studionet",
+      value: studionet,
+    };
+
+    vi.mocked(inquirer.prompt).mockResolvedValue({
+      selectedNetwork: mockSelectedNetwork,
+    });
+
+    await networkActions.setNetwork();
+
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith(
+      "network",
+      JSON.stringify(mockSelectedNetwork),
+    );
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${mockSelectedNetwork.name}`,
+    );
+  });
+
+  test("setNetwork method handles interactive selection of testnet-asimov", async () => {
+    const mockSelectedNetwork = {
+      name: testnetAsimov.name,
+      alias: "testnet-asimov",
+      value: testnetAsimov,
+    };
+
+    vi.mocked(inquirer.prompt).mockResolvedValue({
+      selectedNetwork: mockSelectedNetwork,
+    });
+
+    await networkActions.setNetwork();
+
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith(
+      "network",
+      JSON.stringify(mockSelectedNetwork),
+    );
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${mockSelectedNetwork.name}`,
+    );
+  });
+
+  test("setNetwork method handles case-sensitive network names", async () => {
+    await networkActions.setNetwork("LOCALNET");
+
+    expect(networkActions["failSpinner"]).toHaveBeenCalledWith("Network LOCALNET not found");
+    expect(networkActions["writeConfig"]).not.toHaveBeenCalled();
+  });
+
+  test("setNetwork method handles partial network names", async () => {
+    await networkActions.setNetwork("local");
+
+    expect(networkActions["failSpinner"]).toHaveBeenCalledWith("Network local not found");
+    expect(networkActions["writeConfig"]).not.toHaveBeenCalled();
+  });
+});

--- a/tests/commands/network.test.ts
+++ b/tests/commands/network.test.ts
@@ -1,0 +1,60 @@
+import {Command} from "commander";
+import {vi, describe, beforeEach, afterEach, test, expect} from "vitest";
+import {initializeNetworkCommands} from "../../src/commands/network";
+import {NetworkActions} from "../../src/commands/network/setNetwork";
+
+vi.mock("../../src/commands/network/setNetwork");
+
+describe("network commands", () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = new Command();
+    initializeNetworkCommands(program);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("NetworkActions.setNetwork is called with the correct network name", async () => {
+    program.parse(["node", "test", "network", "localnet"]);
+    expect(NetworkActions).toHaveBeenCalledTimes(1);
+    expect(NetworkActions.prototype.setNetwork).toHaveBeenCalledWith("localnet");
+  });
+
+  test("NetworkActions.setNetwork is called with testnet-asimov", async () => {
+    program.parse(["node", "test", "network", "testnet-asimov"]);
+    expect(NetworkActions).toHaveBeenCalledTimes(1);
+    expect(NetworkActions.prototype.setNetwork).toHaveBeenCalledWith("testnet-asimov");
+  });
+
+  test("NetworkActions.setNetwork is called with studionet", async () => {
+    program.parse(["node", "test", "network", "studionet"]);
+    expect(NetworkActions).toHaveBeenCalledTimes(1);
+    expect(NetworkActions.prototype.setNetwork).toHaveBeenCalledWith("studionet");
+  });
+
+  test("NetworkActions.setNetwork is called without a network name", async () => {
+    program.parse(["node", "test", "network"]);
+    expect(NetworkActions).toHaveBeenCalledTimes(1);
+    expect(NetworkActions.prototype.setNetwork).toHaveBeenCalledWith(undefined);
+  });
+
+  test("NetworkActions is instantiated when the command is executed", async () => {
+    program.parse(["node", "test", "network", "localnet"]);
+    expect(NetworkActions).toHaveBeenCalledTimes(1);
+  });
+
+  test("NetworkActions.setNetwork is called without throwing errors for valid network", async () => {
+    program.parse(["node", "test", "network", "localnet"]);
+    vi.mocked(NetworkActions.prototype.setNetwork).mockResolvedValue();
+    expect(() => program.parse(["node", "test", "network", "localnet"])).not.toThrow();
+  });
+
+  test("NetworkActions.setNetwork is called with empty string", async () => {
+    program.parse(["node", "test", "network", ""]);
+    expect(NetworkActions).toHaveBeenCalledTimes(1);
+    expect(NetworkActions.prototype.setNetwork).toHaveBeenCalledWith("");
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, vi, expect } from "vitest";
-import { initializeCLI } from "../src/index";
+import {describe, it, vi, expect} from "vitest";
+import {initializeCLI} from "../src/index";
 
 vi.mock("commander", () => ({
   program: {
@@ -37,6 +37,9 @@ vi.mock("../src/commands/scaffold", () => ({
   initializeScaffoldCommands: vi.fn(),
 }));
 
+vi.mock("../src/commands/network", () => ({
+  initializeNetworkCommands: vi.fn(),
+}));
 
 describe("CLI", () => {
   it("should initialize CLI", () => {


### PR DESCRIPTION
Fixes: DXP-353

## Add Network Selection Command 
This PR introduces a new network command that allows users to select and configure different GenLayer networks for the CLI.

## Features Added
- New network command: Enables users to switch between different GenLayer networks
- Interactive network selection: Prompts users to choose from available networks when no network is specified
- Support for multiple networks:
    - localnet (Local development network)
    - studionet (Studio network)
    - testnet-asimov (Asimov testnet) 
- Network persistence: Selected network is saved to configuration and used across CLI operations

## Technical Changes
- Added NetworkActions class with setNetwork() method
- Updated BaseAction to use configured network instead of hardcoded localnet
- Enhanced client creation to respect network configuration
- Added comprehensive test coverage for network functionality
- Updated dependencies: genlayer-js from ^0.9.0 to ^0.11.0

## Usage
```bash
# Interactive network selection
genlayer network

# Direct network selection by name
genlayer network "GenLayer Localnet"

# Direct network selection by alias  
genlayer network localnet
genlayer network studionet
genlayer network testnet-asimov
```

## Testing
- Added unit tests for NetworkActions class
- Added integration tests for network command initialization
- Updated existing deploy tests to handle network configuration
- All tests passing with comprehensive coverage